### PR TITLE
The TCL 2020 data on the gfw-data-lake is no longer accessible, so I …

### DIFF
--- a/burn_date/hansen_burnyear_final.py
+++ b/burn_date/hansen_burnyear_final.py
@@ -23,7 +23,7 @@ def hansen_burnyear(tile_id, no_upload):
     # once metadata tags have been added.
     out_tile_no_tag = '{0}_{1}_no_tag.tif'.format(tile_id, cn.pattern_burn_year)
     out_tile = '{0}_{1}.tif'.format(tile_id, cn.pattern_burn_year)
-    loss = '{0}.tif'.format(tile_id)
+    loss = '{0}_{1}.tif'.format(cn.pattern_loss, tile_id)
 
     # Does not continue processing tile if no loss (because there will not be any output)
     if not os.path.exists(loss):

--- a/carbon_pools/create_carbon_pools.py
+++ b/carbon_pools/create_carbon_pools.py
@@ -70,7 +70,7 @@ def create_AGC(tile_id, sensit_type, carbon_pool_extent, no_upload):
         loss_year = '{}_{}.tif'.format(tile_id, cn.pattern_Mekong_loss_processed)
     else:
         uu.print_log("    Hansen loss tile found for {}".format(tile_id))
-        loss_year = '{0}.tif'.format(tile_id)
+        loss_year = '{0}_{1}.tif'.format(cn.pattern_loss, tile_id)
 
     # This input is required to exist
     loss_year_src = rasterio.open(loss_year)

--- a/constants_and_names.py
+++ b/constants_and_names.py
@@ -146,8 +146,8 @@ gain_spreadsheet = 'gain_rate_continent_ecozone_age_20200820.xlsx'
 gain_spreadsheet_dir = os.path.join(s3_base_dir, 'removal_rate_tables/')
 
 # Annual Hansen loss tiles (2001-2020)
-pattern_loss = ''
-loss_dir = 's3://gfw-data-lake/umd_tree_cover_loss/v1.8/raw/geotiff/'
+pattern_loss = 'GFW2020'
+loss_dir = 's3://gfw2-data/forest_change/hansen_2020/'
 
 # Hansen gain tiles (2001-2012)
 pattern_gain = 'Hansen_GFC2015_gain'

--- a/emissions/cpp_util/calc_gross_emissions_convert_to_grassland.cpp
+++ b/emissions/cpp_util/calc_gross_emissions_convert_to_grassland.cpp
@@ -94,7 +94,7 @@ string litter_name = infolder + tile_id + constants::litter_C_emis_year + ".tif"
 string soil_name = infolder + tile_id + constants::soil_C_emis_year + ".tif";
 
 // Other inputs
-string loss_name = infolder + tile_id + ".tif";
+string loss_name = infolder + constants::lossyear + tile_id + ".tif";
 string burn_name = infolder + tile_id + constants::burnyear;
 string ecozone_name = infolder + tile_id + constants::fao_ecozones;
 string climate_name = infolder + tile_id + constants::climate_zones;

--- a/emissions/cpp_util/calc_gross_emissions_generic.cpp
+++ b/emissions/cpp_util/calc_gross_emissions_generic.cpp
@@ -103,7 +103,7 @@ if (sensit_type != "std") {
 }
 
 // Other inputs
-string loss_name = infolder + tile_id + ".tif";
+string loss_name = infolder + constants::lossyear + tile_id + ".tif";
 
 if (sensit_type == "legal_Amazon_loss") {
     loss_name = infolder + tile_id + constants::legal_Amazon_loss;

--- a/emissions/cpp_util/calc_gross_emissions_no_shifting_ag.cpp
+++ b/emissions/cpp_util/calc_gross_emissions_no_shifting_ag.cpp
@@ -94,7 +94,7 @@ string litter_name = infolder + tile_id + constants::litter_C_emis_year + ".tif"
 string soil_name = infolder + tile_id + constants::soil_C_emis_year + ".tif";
 
 // Other inputs
-string loss_name = infolder + tile_id + ".tif";
+string loss_name = infolder + constants::lossyear + tile_id + ".tif";
 string burn_name = infolder + tile_id + constants::burnyear;
 string ecozone_name = infolder + tile_id + constants::fao_ecozones;
 string climate_name = infolder + tile_id + constants::climate_zones;

--- a/emissions/cpp_util/calc_gross_emissions_soil_only.cpp
+++ b/emissions/cpp_util/calc_gross_emissions_soil_only.cpp
@@ -95,7 +95,7 @@ string litter_name = infolder + tile_id + constants::litter_C_emis_year + ".tif"
 string soil_name = infolder + tile_id + constants::soil_C_emis_year + ".tif";
 
 // Other inputs
-string loss_name = infolder + tile_id + ".tif";
+string loss_name = infolder + constants::lossyear + tile_id + ".tif";
 string burn_name = infolder + tile_id + constants::burnyear;
 string ecozone_name = infolder + tile_id + constants::fao_ecozones;
 string climate_name = infolder + tile_id + constants::climate_zones;

--- a/emissions/cpp_util/constants.h
+++ b/emissions/cpp_util/constants.h
@@ -34,6 +34,7 @@ namespace constants
 
     constexpr char legal_Amazon_loss[] = "_legal_Amazon_annual_loss_2001_2019.tif";
 
+    constexpr char lossyear[] = "GFW2020_";
     constexpr char burnyear[] = "_burnyear_with_Hansen_loss.tif";
     constexpr char fao_ecozones[] = "_fao_ecozones_bor_tem_tro_processed.tif";
     constexpr char climate_zones[] = "_climate_zone_processed.tif";

--- a/gain/forest_age_category_IPCC.py
+++ b/gain/forest_age_category_IPCC.py
@@ -48,7 +48,7 @@ def forest_age_category(tile_id, gain_table_dict, pattern, sensit_type, no_uploa
     elif sensit_type == 'Mekong_loss':
         loss = '{0}_{1}.tif'.format(tile_id, cn.pattern_Mekong_loss_processed)
     else:
-        loss = '{0}.tif'.format(tile_id)
+        loss = '{0}_{1}.tif'.format(cn.pattern_loss, tile_id)
         uu.print_log("Using Hansen loss tile {0} for {1} model run".format(tile_id, sensit_type))
 
     uu.print_log("  Assigning age categories")

--- a/gain/gain_year_count_all_forest_types.py
+++ b/gain/gain_year_count_all_forest_types.py
@@ -15,7 +15,7 @@ def tile_names(tile_id, sensit_type):
     if sensit_type == 'legal_Amazon_loss':
         loss = '{0}_{1}.tif'.format(tile_id, cn.pattern_Brazil_annual_loss_processed)
     else:
-        loss = '{0}.tif'.format(tile_id)
+        loss = '{0}_{1}.tif'.format(cn.pattern_loss, tile_id)
     gain = '{0}_{1}.tif'.format(cn.pattern_gain, tile_id)
     model_extent = uu.sensit_tile_rename(sensit_type, tile_id, cn.pattern_model_extent)
 

--- a/run_full_model.py
+++ b/run_full_model.py
@@ -554,7 +554,7 @@ def main ():
 
         for tile_to_delete in tiles_to_delete:
             os.remove(tile_to_delete)
-        uu.print_log(":::::Deleted {0} aux.xml files: {1}".formt(len(tiles_to_delete), tiles_to_delete), "\n")
+        uu.print_log(":::::Deleted {0} aux.xml files: {1}".format(len(tiles_to_delete), tiles_to_delete), "\n")
 
 
         uu.print_log(":::::Creating 4x4 km aggregate maps")

--- a/universal_util.py
+++ b/universal_util.py
@@ -587,13 +587,8 @@ def count_tiles_s3(source, pattern=None):
             num = len(line.strip('\n').split(" "))
             tile_name = line.strip('\n').split(" ")[num - 1]
 
-            if pattern == '':  # For Hansen loss tiles, which have no pattern
-                if tile_name.endswith('.tif'):
-                    tile_id = get_tile_id(tile_name)
-                    file_list.append(tile_id)
-
             # For gain, tcd, and pixel area tiles, which have the tile_id after the the pattern
-            elif pattern in [cn.pattern_gain, cn.pattern_tcd, cn.pattern_pixel_area]:
+            if pattern in [cn.pattern_gain, cn.pattern_tcd, cn.pattern_pixel_area, cn.pattern_loss]:
                 if tile_name.endswith('.tif'):
                     tile_id = get_tile_id(tile_name)
                     file_list.append(tile_id)
@@ -649,9 +644,7 @@ def s3_flexible_download(source_dir, pattern, dest, sensit_type, tile_id_list):
 
         # Creates a full download name (path and file)
         for tile_id in tile_id_list:
-            if pattern == cn.pattern_loss:   # For Hansen loss tiles
-                source = '{0}{1}.tif'.format(source_dir, tile_id)
-            elif pattern in [cn.pattern_gain, cn.pattern_tcd, cn.pattern_pixel_area]:   # For tiles that do not have the tile_id first
+            if pattern in [cn.pattern_gain, cn.pattern_tcd, cn.pattern_pixel_area, cn.pattern_loss]:   # For tiles that do not have the tile_id first
                 source = '{0}{1}_{2}.tif'.format(source_dir, pattern, tile_id)
             else:  # For every other type of tile
                 source = '{0}{1}_{2}.tif'.format(source_dir, tile_id, pattern)
@@ -674,26 +667,9 @@ def s3_folder_download(source, dest, sensit_type, pattern = None):
     local_tile_count = len(glob.glob('*{}*.tif'.format(pattern)))
 
     # For tile types that have the tile_id after the pattern
-    if pattern in [cn.pattern_gain, cn.pattern_tcd, cn.pattern_pixel_area]:
+    if pattern in [cn.pattern_gain, cn.pattern_tcd, cn.pattern_pixel_area, cn.pattern_loss]:
 
         local_tile_count = len(glob.glob('{}*.tif'.format(pattern)))
-
-
-    # Because loss tiles don't have a pattern after the tile_id, thee count of loss tiles on the spot machine
-    # needs to be handled separately.
-    if pattern == '':
-
-        local_tile_count = 0
-
-        all_local_tiles = glob.glob('*tif')
-
-        for tile in all_local_tiles:
-
-            # Loss tiles are 12 characters long (just [tile_id].tif). Only tiles with that length name are counted.
-            # Using regex to identify the loss tiles would be better but I couldn't get that to work.
-            if len(tile) == 12:
-                local_tile_count = local_tile_count + 1
-
 
     print_log("There are", local_tile_count, "tiles on the spot machine with the pattern", pattern)
 


### PR DESCRIPTION
…changed the model to use the tiles on gfw2-data instead. The gfw2-data tiles have a prefix before the tile_id, so I had to go back and change the TCL tile pattern recognition to use the new prefix pattern. I reran this with the changed TCL source/pattern on 00N_110 in Docker locally and results seemed the same as for the v1.2.1 model run, so I think I changed this correctly.

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Make sure you are requesting to pull a topic/feature/bugfix branch (right side). Don't request your master!
- [x] Make sure you are making a pull request against the develop branch (left side). Also you should start your branch off our develop.
- [x] Check the commit's or even all commits' message styles matches our requested structure.
- [x] Check your code additions will fail neither code linting checks nor unit test.



## Pull request type

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?

- When I made model v1.2.1 originally using the 2020 TCL, it pulled the TCL tiles from gfw-data-lake. However, since then the data-lake has become inaccessible and so the model wasn't able to access the TCL tiles.


## What is the new behavior?

- The model uses the TCL 2020 tiles in gfw2-data instead.
- The pattern for the TCL tiles in gfw2-data is different from in the gfw-data-lake, so I had to change various places where the loss pattern is referenced.


## Does this introduce a breaking change?

- [ ] Yes
- [x] No



## Other information

Tested locally on 00N_110E. Results for all stages were comparable to main v1.2.1 model run. 
