### PR TITLE
Handles compiler warnings in the C++ emissions script based on a ques…

### DIFF
--- a/emissions/cpp_util/calc_gross_emissions_generic.cpp
+++ b/emissions/cpp_util/calc_gross_emissions_generic.cpp
@@ -377,19 +377,44 @@ float out_data20[xsize];
 for (y=0; y<ysize; y++)
 {
 
-INBAND1->RasterIO(GF_Read, 0, y, xsize, 1, agc_data, xsize, 1, GDT_Float32, 0, 0);
-INBAND2->RasterIO(GF_Read, 0, y, xsize, 1, bgc_data, xsize, 1, GDT_Float32, 0, 0);
-INBAND3->RasterIO(GF_Read, 0, y, xsize, 1, drivermodel_data, xsize, 1, GDT_Float32, 0, 0);
-INBAND4->RasterIO(GF_Read, 0, y, xsize, 1, loss_data, xsize, 1, GDT_Float32, 0, 0);
-INBAND5->RasterIO(GF_Read, 0, y, xsize, 1, peat_data, xsize, 1, GDT_Float32, 0, 0);
-INBAND6->RasterIO(GF_Read, 0, y, xsize, 1, burn_data, xsize, 1, GDT_Float32, 0, 0);
-INBAND7->RasterIO(GF_Read, 0, y, xsize, 1, ifl_primary_data, xsize, 1, GDT_Float32, 0, 0);
-INBAND8->RasterIO(GF_Read, 0, y, xsize, 1, ecozone_data, xsize, 1, GDT_Float32, 0, 0);
-INBAND9->RasterIO(GF_Read, 0, y, xsize, 1, climate_data, xsize, 1, GDT_Float32, 0, 0);
-INBAND10->RasterIO(GF_Read, 0, y, xsize, 1, dead_data, xsize, 1, GDT_Float32, 0, 0);
-INBAND11->RasterIO(GF_Read, 0, y, xsize, 1, litter_data, xsize, 1, GDT_Float32, 0, 0);
-INBAND12->RasterIO(GF_Read, 0, y, xsize, 1, soil_data, xsize, 1, GDT_Float32, 0, 0);
-INBAND13->RasterIO(GF_Read, 0, y, xsize, 1, plant_data, xsize, 1, GDT_Float32, 0, 0);
+// The following RasterIO reads (and the RasterIO writes at the end) produced compile warnings about unused results
+// (warning: ignoring return value of 'CPLErr GDALRasterBand::RasterIO(GDALRWFlag, int, int, int, int, void*, int, int, GDALDataType, GSpacing, GSpacing, GDALRasterIOExtraArg*)', declared with attribute warn_unused_result [-Wunused-result]).
+// I asked how to handle or silence the warnings at https://stackoverflow.com/questions/72410931/how-to-handle-warn-unused-result-wunused-result/72410978#72410978.
+// The code below handles the warnings by directing them to arguments, which are then checked.
+// For cerr instead of std::err: https://www.geeksforgeeks.org/cerr-standard-error-stream-object-in-cpp/
+
+// Error code returned by each line saved as their own argument
+CPLErr errcodeIn1 = INBAND1->RasterIO(GF_Read, 0, y, xsize, 1, agc_data, xsize, 1, GDT_Float32, 0, 0);
+CPLErr errcodeIn2 = INBAND2->RasterIO(GF_Read, 0, y, xsize, 1, bgc_data, xsize, 1, GDT_Float32, 0, 0);
+CPLErr errcodeIn3 = INBAND3->RasterIO(GF_Read, 0, y, xsize, 1, drivermodel_data, xsize, 1, GDT_Float32, 0, 0);
+CPLErr errcodeIn4 = INBAND4->RasterIO(GF_Read, 0, y, xsize, 1, loss_data, xsize, 1, GDT_Float32, 0, 0);
+CPLErr errcodeIn5 = INBAND5->RasterIO(GF_Read, 0, y, xsize, 1, peat_data, xsize, 1, GDT_Float32, 0, 0);
+CPLErr errcodeIn6 = INBAND6->RasterIO(GF_Read, 0, y, xsize, 1, burn_data, xsize, 1, GDT_Float32, 0, 0);
+CPLErr errcodeIn7 = INBAND7->RasterIO(GF_Read, 0, y, xsize, 1, ifl_primary_data, xsize, 1, GDT_Float32, 0, 0);
+CPLErr errcodeIn8 = INBAND8->RasterIO(GF_Read, 0, y, xsize, 1, ecozone_data, xsize, 1, GDT_Float32, 0, 0);
+CPLErr errcodeIn9 = INBAND9->RasterIO(GF_Read, 0, y, xsize, 1, climate_data, xsize, 1, GDT_Float32, 0, 0);
+CPLErr errcodeIn10 = INBAND10->RasterIO(GF_Read, 0, y, xsize, 1, dead_data, xsize, 1, GDT_Float32, 0, 0);
+CPLErr errcodeIn11 = INBAND11->RasterIO(GF_Read, 0, y, xsize, 1, litter_data, xsize, 1, GDT_Float32, 0, 0);
+CPLErr errcodeIn12 = INBAND12->RasterIO(GF_Read, 0, y, xsize, 1, soil_data, xsize, 1, GDT_Float32, 0, 0);
+CPLErr errcodeIn13 = INBAND13->RasterIO(GF_Read, 0, y, xsize, 1, plant_data, xsize, 1, GDT_Float32, 0, 0);
+
+// Number of input files
+int inSize = 13;
+
+// Array of error codes returned from each input
+CPLErr errcodeInArray [inSize] = {errcodeIn1, errcodeIn2, errcodeIn3, errcodeIn4, errcodeIn5, errcodeIn6, errcodeIn7,
+errcodeIn8, errcodeIn9, errcodeIn10, errcodeIn11, errcodeIn12, errcodeIn13};
+
+// Iterates through the input error codes to make sure that the error code is acceptable
+int j;
+
+for (j=0; j<inSize; j++)
+{
+    if (errcodeInArray[j] != 0) {
+        cerr << "rasterIO failed!\n";
+        exit(1);
+    }
+}
 
 for(x=0; x<xsize; x++)
 
@@ -1222,16 +1247,41 @@ for(x=0; x<xsize; x++)
 		}
     }
 
-OUTBAND1->RasterIO( GF_Write, 0, y, xsize, 1, out_data1, xsize, 1, GDT_Float32, 0, 0 );
-OUTBAND2->RasterIO( GF_Write, 0, y, xsize, 1, out_data2, xsize, 1, GDT_Float32, 0, 0 );
-OUTBAND3->RasterIO( GF_Write, 0, y, xsize, 1, out_data3, xsize, 1, GDT_Float32, 0, 0 );
-OUTBAND4->RasterIO( GF_Write, 0, y, xsize, 1, out_data4, xsize, 1, GDT_Float32, 0, 0 );
-OUTBAND5->RasterIO( GF_Write, 0, y, xsize, 1, out_data5, xsize, 1, GDT_Float32, 0, 0 );
-OUTBAND6->RasterIO( GF_Write, 0, y, xsize, 1, out_data6, xsize, 1, GDT_Float32, 0, 0 );
-OUTBAND10->RasterIO( GF_Write, 0, y, xsize, 1, out_data10, xsize, 1, GDT_Float32, 0, 0 );
-OUTBAND11->RasterIO( GF_Write, 0, y, xsize, 1, out_data11, xsize, 1, GDT_Float32, 0, 0 );
-OUTBAND12->RasterIO( GF_Write, 0, y, xsize, 1, out_data12, xsize, 1, GDT_Float32, 0, 0 );
-OUTBAND20->RasterIO( GF_Write, 0, y, xsize, 1, out_data20, xsize, 1, GDT_Float32, 0, 0 );
+// The following RasterIO writes (and the RasterIO reads at the start) produced compile warnings about unused results
+// (warning: ignoring return value of 'CPLErr GDALRasterBand::RasterIO(GDALRWFlag, int, int, int, int, void*, int, int, GDALDataType, GSpacing, GSpacing, GDALRasterIOExtraArg*)', declared with attribute warn_unused_result [-Wunused-result]).
+// I asked how to handle or silence the warnings at https://stackoverflow.com/questions/72410931/how-to-handle-warn-unused-result-wunused-result/72410978#72410978.
+// The code below handles the warnings by directing them to arguments, which are then checked.
+// For cerr instead of std::err: https://www.geeksforgeeks.org/cerr-standard-error-stream-object-in-cpp/
+
+// Error code returned by each line saved as their own argument
+CPLErr errcodeOut1 = OUTBAND1->RasterIO( GF_Write, 0, y, xsize, 1, out_data1, xsize, 1, GDT_Float32, 0, 0 );
+CPLErr errcodeOut2 = OUTBAND2->RasterIO( GF_Write, 0, y, xsize, 1, out_data2, xsize, 1, GDT_Float32, 0, 0 );
+CPLErr errcodeOut3 = OUTBAND3->RasterIO( GF_Write, 0, y, xsize, 1, out_data3, xsize, 1, GDT_Float32, 0, 0 );
+CPLErr errcodeOut4 = OUTBAND4->RasterIO( GF_Write, 0, y, xsize, 1, out_data4, xsize, 1, GDT_Float32, 0, 0 );
+CPLErr errcodeOut5 = OUTBAND5->RasterIO( GF_Write, 0, y, xsize, 1, out_data5, xsize, 1, GDT_Float32, 0, 0 );
+CPLErr errcodeOut6 = OUTBAND6->RasterIO( GF_Write, 0, y, xsize, 1, out_data6, xsize, 1, GDT_Float32, 0, 0 );
+CPLErr errcodeOut10 = OUTBAND10->RasterIO( GF_Write, 0, y, xsize, 1, out_data10, xsize, 1, GDT_Float32, 0, 0 );
+CPLErr errcodeOut11 = OUTBAND11->RasterIO( GF_Write, 0, y, xsize, 1, out_data11, xsize, 1, GDT_Float32, 0, 0 );
+CPLErr errcodeOut12 = OUTBAND12->RasterIO( GF_Write, 0, y, xsize, 1, out_data12, xsize, 1, GDT_Float32, 0, 0 );
+CPLErr errcodeOut20 = OUTBAND20->RasterIO( GF_Write, 0, y, xsize, 1, out_data20, xsize, 1, GDT_Float32, 0, 0 );
+
+// Number of output files
+int outSize = 10;
+
+// Array of error codes returned from each output
+CPLErr errcodeOutArray [outSize] = {errcodeOut1, errcodeOut2, errcodeOut3, errcodeOut4, errcodeOut5, errcodeOut6,
+errcodeOut10, errcodeOut11, errcodeOut12, errcodeOut20};
+
+// Iterates through the output error codes to make sure that the error code is acceptable
+int k;
+
+for (k=0; k<outSize; k++)
+{
+    if (errcodeOutArray[k] != 0) {
+        cerr << "rasterIO failed!\n";
+        exit(1);
+    }
+}
 }
 
 GDALClose(INGDAL1);

--- a/emissions/mp_calculate_gross_emissions.py
+++ b/emissions/mp_calculate_gross_emissions.py
@@ -13,8 +13,8 @@ and convert_to_grassland), do:
 c++ /home/dgibbs/carbon-budget/emissions/cpp_util/calc_gross_emissions_<sensit_type>.cpp -o /home/dgibbs/carbon-budget/emissions/cpp_util/calc_gross_emissions_<sensit_type>.exe -lgdal
 Run by typing python mp_calculate_gross_emissions.py -p [POOL_OPTION] -t [MODEL_TYPE] -l [TILE_LIST] -d [RUN_DATE]
 The Python script will call the compiled C++ code as needed.
-The other C++ scripts (equations.cpp and flu_val.cpp) do not need to be compiled.
-The --emitted_pools-to-use argument specifies whether to calculate gross emissions from biomass+soil or just from soil.
+The other C++ scripts (equations.cpp and flu_val.cpp) do not need to be compiled separately.
+The --pools-to-use argument specifies whether to calculate gross emissions from biomass+soil or just from soil.
 The --model-type argument specifies whether the model run is a sensitivity analysis or standard run.
 Emissions from each driver (including loss that had no driver assigned) gets its own tile, as does all emissions combined.
 Emissions from all drivers is also output as emissions due to CO2 only and emissions due to other GHG (CH4 and N2O).

--- a/readme.md
+++ b/readme.md
@@ -188,6 +188,17 @@ run. Alternatively, you can look at the top of `run_full_model.py` to see the or
 The date component of the output directory on s3 generally must be changed in `constants_and_names.py`
 for each output file. 
 
+##### Running the emissions model
+The gross emissions script is the only part of the model that uses C++. Thus, it must be manually compiled before running.
+There are a few different versions of the emissions script: one for the standard model and a few other for
+sensitivity analyses.
+The command for compiling the C++ script is (subbing in the actual file name): 
+
+`c++ /usr/local/app/emissions/cpp_util/calc_gross_emissions_[VERSION].cpp -o /usr/local/app/emissions/cpp_util/calc_gross_emissions_[VERSION].exe -lgdal`
+
+For the standard model and the sensitivity analyses that don't specifically affect emissions, it is:
+
+`c++ /usr/local/app/emissions/cpp_util/calc_gross_emissions_generic.cpp -o /usr/local/app/emissions/cpp_util/calc_gross_emissions_generic.exe -lgdal`
 
 #### Master script 
 The master script runs through all of the non-preparatory scripts in the model: some removal factor creation, gross removals, carbon
@@ -250,18 +261,6 @@ compare aggregated outputs to specified file (although not used in this specific
 
 `python run_full_model.py -nu -t biomass_swap -s model_extent -r false -d 20229999 -l 00N_000E,00N_110E,40N_90W -ce loss -p biomass_soil -tcd 30 -sagg s3://gfw2-data/climate/carbon_model/0_04deg_output_aggregation/biomass_soil/standard/20200914/net_flux_Mt_CO2e_biomass_soil_per_year_tcd30_0_4deg_modelv1_2_0_std_20200914.tif -ln "Multi-tile test"`
 
-
-##### Running the emissions model
-The gross emissions script is the only part of the model that uses C++. Thus, it must be manually compiled before running.
-There are a few different versions of the emissions script: one for the standard model and a few other for
-sensitivitity analyses.
-The command for compiling the C++ script is (subbing in the actual file name): 
-
-`c++ /usr/local/app/emissions/cpp_util/calc_gross_emissions_[VERSION].cpp -o /usr/local/app/emissions/cpp_util/calc_gross_emissions_[VERSION].exe -lgdal`
-
-For the standard model and the sensitivity analyses that don't specifically affect emissions, it is:
-
-`c++ /usr/local/app/emissions/cpp_util/calc_gross_emissions_generic.cpp -o /usr/local/app/emissions/cpp_util/calc_gross_emissions_generic.exe -lgdal`
 
 ### Sensitivity analysis
 Several variations of the model are included; these are the sensitivity variants, as they use different inputs or parameters. 


### PR DESCRIPTION
…tion I asked on Stackoverflow (https://stackoverflow.com/questions/72410931/how-to-handle-warn-unused-result-wunused-result/72410978#72410978). RasterIO read and write warnings were created during compilation because the return value of the read and write lines were being ignored. This now puts the returned error codes into their own arguments, which are then checked for non-0 error codes.

Also, I checked whether checking the returned error codes would slow down the emissions script at all. It didn't slow things down. For 00N_110E, the previous version (which had the warnings during compilation) took around 20 minutes. With this error handling, it now takes about 11:30. I don't know why it should be faster now.

Also, I checked the 00N_110E output emissions tiles against the tiles I got from the 1.2.2 full model run. The tiles appear identical.

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Check the commit's or even all commits' message styles matches our requested structure.
- [x] Check your code additions will fail neither code linting checks nor unit test.



## Pull request type

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
When compiling the emissions C++, I would get one warning for each RasterIO read or write line (13 and 10, respectively) that said `warning: ignoring return value of 'CPLErr GDALRasterBand::RasterIO(GDALRWFlag, int, int, int, int, void*, int, int, GDALDataType, GSpacing, GSpacing, GDALRasterIOExtraArg*)', declared with attribute warn_unused_result [-Wunused-result]`. These warnings mean that the error code (regardless of what it is or whether there is an error) that is being returned by the read or write line isn't being used at all; the error code just gets lost. These warnings had been there for as long as I have been working on the model, and I remember Sam Gibbes telling me that they were fine and didn't cause any issues. Indeed, they have never caused issues, but it is unsightly to get 23 warnings whenever you compile. 

## What is the new behavior?

- The compile RasterIO read and write warnings are now handled (not suppressed). I couldn't figure out how to do it myself so I asked on Stackoverflow (https://stackoverflow.com/questions/72410931/how-to-handle-warn-unused-result-wunused-result/72410978#72410978).
- The error codes get read into variables, which make an array and are then checked. Error code 0 is fine, so if the code is anything but 0, the script stops. 

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

It's cosmetic but nice not to have 23 warnings every time I compile this. 
