### PR TITLE
Feature/carbon pool testing

### DIFF
--- a/carbon_pools/create_carbon_pools.py
+++ b/carbon_pools/create_carbon_pools.py
@@ -658,8 +658,18 @@ def create_deadwood_litter(tile_id, mang_deadwood_AGB_ratio, mang_litter_AGB_rat
 
 def deadwood_litter_equations(bor_tem_trop_window, deadwood_2000_output, elevation_window, litter_2000_output,
                               natrl_forest_biomass_window, precip_window):
+    """
+    :param bor_tem_trop_window: array representing boreal, temperate or tropical climate domains
+    :param deadwood_2000_output: array representing the deadwood output
+    :param elevation_window: array representing elevation
+    :param litter_2000_output: array representing litter output
+    :param natrl_forest_biomass_window: array representing aboveground biomass
+    :param precip_window: array representing annual precipitation
+    :return: arrays of deadwood and litter carbon
+    """
+
     # The deadwood and litter conversions generally come from here: https://cdm.unfccc.int/methodologies/ARmethodologies/tools/ar-am-tool-12-v3.0.pdf, p. 17-18
-    # They depend on the elevation, precipitation, and broad biome category (boreal/temperate/tropical).
+    # They depend on the elevation, precipitation, and climate domain (boreal/temperate/tropical).
     # For some reason, the masks need to be named different variables for each equation.
     # If they all have the same name (e.g., elev_mask and condition_mask are reused), then at least the condition_mask_4
     # equation won't work properly.)

--- a/carbon_pools/create_carbon_pools.py
+++ b/carbon_pools/create_carbon_pools.py
@@ -656,68 +656,68 @@ def create_deadwood_litter(tile_id, mang_deadwood_AGB_ratio, mang_litter_AGB_rat
         uu.end_of_fx_summary(start, tile_id, cn.pattern_deadwood_2000)
 
 
-def deadwood_litter_equations(bor_tem_trop_window, deadwood_2000_output,
-                              elevation_window, litter_2000_output,
+def deadwood_litter_equations(bor_tem_trop_window, deadwood_2000_output, elevation_window, litter_2000_output,
                               natrl_forest_biomass_window, precip_window):
     # The deadwood and litter conversions generally come from here: https://cdm.unfccc.int/methodologies/ARmethodologies/tools/ar-am-tool-12-v3.0.pdf, p. 17-18
     # They depend on the elevation, precipitation, and broad biome category (boreal/temperate/tropical).
     # For some reason, the masks need to be named different variables for each equation.
     # If they all have the same name (e.g., elev_mask and condition_mask are reused), then at least the condition_mask_4
     # equation won't work properly.)
+
     # Equation for elevation <= 2000, precip <= 1000, bor/temp/trop = 1 (tropical)
     elev_mask_1 = elevation_window <= 2000
     precip_mask_1 = precip_window <= 1000
     ecozone_mask_1 = bor_tem_trop_window == 1
     condition_mask_1 = elev_mask_1 & precip_mask_1 & ecozone_mask_1
-    agb_masked_1 = np.ma.array(natrl_forest_biomass_window,
-                               mask=np.invert(condition_mask_1))
+    agb_masked_1 = np.ma.array(natrl_forest_biomass_window, mask=np.invert(condition_mask_1))
     deadwood_masked = agb_masked_1 * 0.02 * cn.biomass_to_c_non_mangrove
     deadwood_2000_output = deadwood_2000_output + deadwood_masked.filled(0)
     litter_masked = agb_masked_1 * 0.04 * cn.biomass_to_c_non_mangrove_litter
     litter_2000_output = litter_2000_output + litter_masked.filled(0)
+
     # Equation for elevation <= 2000, 1000 < precip <= 1600, bor/temp/trop = 1 (tropical)
     elev_mask_2 = elevation_window <= 2000
     precip_mask_2 = (precip_window > 1000) & (precip_window <= 1600)
     ecozone_mask_2 = bor_tem_trop_window == 1
     condition_mask_2 = elev_mask_2 & precip_mask_2 & ecozone_mask_2
-    agb_masked_2 = np.ma.array(natrl_forest_biomass_window,
-                               mask=np.invert(condition_mask_2))
+    agb_masked_2 = np.ma.array(natrl_forest_biomass_window, mask=np.invert(condition_mask_2))
     deadwood_masked = agb_masked_2 * 0.01 * cn.biomass_to_c_non_mangrove
     deadwood_2000_output = deadwood_2000_output + deadwood_masked.filled(0)
     litter_masked = agb_masked_2 * 0.01 * cn.biomass_to_c_non_mangrove_litter
     litter_2000_output = litter_2000_output + litter_masked.filled(0)
+
     # Equation for elevation <= 2000, precip > 1600, bor/temp/trop = 1 (tropical)
     elev_mask_3 = elevation_window <= 2000
     precip_mask_3 = precip_window > 1600
     ecozone_mask_3 = bor_tem_trop_window == 1
     condition_mask_3 = elev_mask_3 & precip_mask_3 & ecozone_mask_3
-    agb_masked_3 = np.ma.array(natrl_forest_biomass_window,
-                               mask=np.invert(condition_mask_3))
+    agb_masked_3 = np.ma.array(natrl_forest_biomass_window, mask=np.invert(condition_mask_3))
     deadwood_masked = agb_masked_3 * 0.06 * cn.biomass_to_c_non_mangrove
     deadwood_2000_output = deadwood_2000_output + deadwood_masked.filled(0)
     litter_masked = agb_masked_3 * 0.01 * cn.biomass_to_c_non_mangrove_litter
     litter_2000_output = litter_2000_output + litter_masked.filled(0)
+
     # Equation for elevation > 2000, precip = any value, bor/temp/trop = 1 (tropical)
     elev_mask_4 = elevation_window > 2000
     ecozone_mask_4 = bor_tem_trop_window == 1
     condition_mask_4 = elev_mask_4 & ecozone_mask_4
-    agb_masked_4 = np.ma.array(natrl_forest_biomass_window,
-                               mask=np.invert(condition_mask_4))
+    agb_masked_4 = np.ma.array(natrl_forest_biomass_window,  mask=np.invert(condition_mask_4))
     deadwood_masked = agb_masked_4 * 0.07 * cn.biomass_to_c_non_mangrove
     deadwood_2000_output = deadwood_2000_output + deadwood_masked.filled(0)
     litter_masked = agb_masked_4 * 0.01 * cn.biomass_to_c_non_mangrove_litter
     litter_2000_output = litter_2000_output + litter_masked.filled(0)
+
     # Equation for elevation = any value, precip = any value, bor/temp/trop = 2 or 3 (boreal or temperate)
     ecozone_mask_5 = bor_tem_trop_window != 1
     condition_mask_5 = ecozone_mask_5
-    agb_masked_5 = np.ma.array(natrl_forest_biomass_window,
-                               mask=np.invert(condition_mask_5))
+    agb_masked_5 = np.ma.array(natrl_forest_biomass_window,  mask=np.invert(condition_mask_5))
     deadwood_masked = agb_masked_5 * 0.08 * cn.biomass_to_c_non_mangrove
     deadwood_2000_output = deadwood_2000_output + deadwood_masked.filled(0)
     litter_masked = agb_masked_5 * 0.04 * cn.biomass_to_c_non_mangrove_litter
     litter_2000_output = litter_2000_output + litter_masked.filled(0)
     deadwood_2000_output = deadwood_2000_output.astype('float32')
     litter_2000_output = litter_2000_output.astype('float32')
+
     return deadwood_2000_output, litter_2000_output
 
 

--- a/constants_and_names.py
+++ b/constants_and_names.py
@@ -182,7 +182,7 @@ pixel_area_rewindow_dir = os.path.join(s3_base_dir, 'rewindow/pixel_area/2021062
 
 
 # Spreadsheet with annual removals rates
-gain_spreadsheet = 'gain_rate_continent_ecozone_age_20200820.xlsx'
+gain_spreadsheet = 'gain_rate_continent_ecozone_age_20220914.xlsx'
 gain_spreadsheet_dir = os.path.join(s3_base_dir, 'removal_rate_tables/')
 
 # Annual Hansen loss tiles (2001-2021)

--- a/test/carbon_pools/test_carbon_pools.py
+++ b/test/carbon_pools/test_carbon_pools.py
@@ -14,7 +14,6 @@ def test_deadwood_litter_equations_can_be_called():
         precip_window=np.zeros((1, 1), dtype='float32')
     )
 
-
 def test_deadwood_litter_equations_return_zero_deadwood_for_zero_biomass():
     deadwood, _ = deadwood_litter_equations(
         bor_tem_trop_window=np.zeros((1, 1), dtype='float32'),
@@ -25,7 +24,6 @@ def test_deadwood_litter_equations_return_zero_deadwood_for_zero_biomass():
         precip_window=np.zeros((1, 1), dtype='float32')
     )
     assert deadwood == np.array([0.])
-
 
 def test_deadwood_litter_equations_return_zero_litter_for_zero_biomass():
     _, litter = deadwood_litter_equations(
@@ -39,6 +37,7 @@ def test_deadwood_litter_equations_return_zero_litter_for_zero_biomass():
     assert litter == np.array([0.])
 
 
+# Scenario 1- tropical, low elevation, low precipitation
 def test_deadwood_litter_equations_return_zero_deadwood__tropical_low_elev_low_precip():
     deadwood, _ = deadwood_litter_equations(
         bor_tem_trop_window=np.array([1], dtype='float32'),
@@ -48,8 +47,7 @@ def test_deadwood_litter_equations_return_zero_deadwood__tropical_low_elev_low_p
         natrl_forest_biomass_window=np.array([1], dtype='float32'),
         precip_window=np.array([1], dtype='float32')
     )
-    assert deadwood == np.array([0.02])
-
+    assert deadwood == np.array([0.0094], dtype='float32')
 
 def test_deadwood_litter_equations_return_zero_litter__tropical_low_elev_low_precip():
     _, litter = deadwood_litter_equations(
@@ -60,4 +58,100 @@ def test_deadwood_litter_equations_return_zero_litter__tropical_low_elev_low_pre
         natrl_forest_biomass_window=np.array([1], dtype='float32'),
         precip_window=np.array([1], dtype='float32')
     )
-    assert litter == np.array([0.04])
+    assert litter == np.array([0.0148], dtype='float32')
+
+
+# Scenario 2- tropical, low elevation, moderate precipitation
+def test_deadwood_litter_equations_return_zero_deadwood__tropical_low_elev_mod_precip():
+    deadwood, _ = deadwood_litter_equations(
+        bor_tem_trop_window=np.array([1], dtype='float32'),
+        deadwood_2000_output=np.array([0], dtype='float32'),
+        elevation_window=np.array([1], dtype='float32'),
+        litter_2000_output=np.array([0], dtype='float32'),
+        natrl_forest_biomass_window=np.array([100], dtype='float32'),
+        precip_window=np.array([1600], dtype='float32')
+    )
+    assert deadwood == np.array([0.47], dtype='float32')
+
+def test_deadwood_litter_equations_return_zero_litter__tropical_low_elev_mod_precip():
+    _, litter = deadwood_litter_equations(
+        bor_tem_trop_window=np.array([1], dtype='float32'),
+        deadwood_2000_output=np.array([0], dtype='float32'),
+        elevation_window=np.array([1], dtype='float32'),
+        litter_2000_output=np.array([0], dtype='float32'),
+        natrl_forest_biomass_window=np.array([100], dtype='float32'),
+        precip_window=np.array([1600], dtype='float32')
+    )
+    assert litter == np.array([0.37], dtype='float32')
+
+
+# Scenario 3- tropical, low elevation, high precipitation
+def test_deadwood_litter_equations_return_zero_deadwood__tropical_low_elev_high_precip():
+    deadwood, _ = deadwood_litter_equations(
+        bor_tem_trop_window=np.array([1], dtype='float32'),
+        deadwood_2000_output=np.array([0], dtype='float32'),
+        elevation_window=np.array([1], dtype='float32'),
+        litter_2000_output=np.array([0], dtype='float32'),
+        natrl_forest_biomass_window=np.array([100], dtype='float32'),
+        precip_window=np.array([1601], dtype='float32')
+    )
+    assert deadwood == np.array([2.82], dtype='float32')
+
+def test_deadwood_litter_equations_return_zero_litter__tropical_low_elev_high_precip():
+    _, litter = deadwood_litter_equations(
+        bor_tem_trop_window=np.array([1], dtype='float32'),
+        deadwood_2000_output=np.array([0], dtype='float32'),
+        elevation_window=np.array([1], dtype='float32'),
+        litter_2000_output=np.array([0], dtype='float32'),
+        natrl_forest_biomass_window=np.array([100], dtype='float32'),
+        precip_window=np.array([1601], dtype='float32')
+    )
+    assert litter == np.array([0.37], dtype='float32')
+
+
+# Scenario 4- tropical, high elevation, any precipitation
+def test_deadwood_litter_equations_return_zero_deadwood__tropical_high_elev_any_precip():
+    deadwood, _ = deadwood_litter_equations(
+        bor_tem_trop_window=np.array([1], dtype='float32'),
+        deadwood_2000_output=np.array([0], dtype='float32'),
+        elevation_window=np.array([2001], dtype='float32'),
+        litter_2000_output=np.array([0], dtype='float32'),
+        natrl_forest_biomass_window=np.array([100], dtype='float32'),
+        precip_window=np.array([1], dtype='float32')
+    )
+    assert deadwood == np.array([3.29], dtype='float32')
+
+def test_deadwood_litter_equations_return_zero_litter__tropical_high_elev_any_precip():
+    _, litter = deadwood_litter_equations(
+        bor_tem_trop_window=np.array([1], dtype='float32'),
+        deadwood_2000_output=np.array([0], dtype='float32'),
+        elevation_window=np.array([2001], dtype='float32'),
+        litter_2000_output=np.array([0], dtype='float32'),
+        natrl_forest_biomass_window=np.array([100], dtype='float32'),
+        precip_window=np.array([1], dtype='float32')
+    )
+    assert litter == np.array([0.37], dtype='float32')
+
+
+# Scenario 5- non-tropical, any elevation, any precipitation
+def test_deadwood_litter_equations_return_zero_deadwood__non_tropical_any_elev_any_precip():
+    deadwood, _ = deadwood_litter_equations(
+        bor_tem_trop_window=np.array([2], dtype='float32'),
+        deadwood_2000_output=np.array([0], dtype='float32'),
+        elevation_window=np.array([1], dtype='float32'),
+        litter_2000_output=np.array([0], dtype='float32'),
+        natrl_forest_biomass_window=np.array([100], dtype='float32'),
+        precip_window=np.array([1], dtype='float32')
+    )
+    assert deadwood == np.array([3.76], dtype='float32')
+
+def test_deadwood_litter_equations_return_zero_litter__non_tropical_any_elev_any_precip():
+    _, litter = deadwood_litter_equations(
+        bor_tem_trop_window=np.array([2], dtype='float32'),
+        deadwood_2000_output=np.array([0], dtype='float32'),
+        elevation_window=np.array([1], dtype='float32'),
+        litter_2000_output=np.array([0], dtype='float32'),
+        natrl_forest_biomass_window=np.array([100], dtype='float32'),
+        precip_window=np.array([1], dtype='float32')
+    )
+    assert litter == np.array([1.48], dtype='float32')

--- a/test/carbon_pools/test_carbon_pools.py
+++ b/test/carbon_pools/test_carbon_pools.py
@@ -1,76 +1,7 @@
 import numpy as np
 import pytest
 
-from carbon_pools.create_carbon_pools import create_deadwood_litter, \
-    deadwood_litter_equations
-
-
-def arid_pools(**kwargs):
-    pass
-
-
-@pytest.mark.xfail
-def test_can_call_function():
-    result = create_deadwood_litter("", {}, {}, [])
-    assert result is None
-
-
-@pytest.mark.xfail
-def test_can_call_with_biomass_swap():
-    result = create_deadwood_litter("", {}, {}, [], "biomass_swap", True)
-    assert result is None
-
-
-@pytest.mark.xfail
-def test_arid_pools():
-    result = arid_pools(
-        elevation_window=2000,
-        precip_window=1000,
-        bor_tem_trop_window=1,
-        natrl_forest_biomass_window=np.ma.array([1]),
-        deadwood_2000_output=np.ma.array([1]),
-        litter_2000_output=np.ma.array([1])
-    )
-    assert result == (np.ma.array([1.0094]), np.ma.array([1.0148]))
-
-
-@pytest.mark.xfail
-def test_arid_pools_with_no_deadwood_or_litter():
-    result = arid_pools(
-        elevation_window=2000,
-        precip_window=1000,
-        bor_tem_trop_window=1,
-        natrl_forest_biomass_window=np.ma.array([1]),
-        deadwood_2000_output=np.ma.array([0]),
-        litter_2000_output=np.ma.array([0])
-    )
-    assert result == (np.ma.array([0.0094]), np.ma.array([0.0148]))
-
-
-@pytest.mark.xfail
-def test_arid_pools_no_biomass_means_none_is_added():
-    result = arid_pools(
-        elevation_window=2000,
-        precip_window=1000,
-        bor_tem_trop_window=1,
-        natrl_forest_biomass_window=np.ma.array([0]),
-        deadwood_2000_output=np.ma.array([1]),
-        litter_2000_output=np.ma.array([1])
-    )
-    assert result == (np.ma.array([1]), np.ma.array([1]))
-
-
-@pytest.mark.xfail
-def test_arid_pools_fraction_of_biomass():
-    result = arid_pools(
-        elevation_window=2000,
-        precip_window=1000,
-        bor_tem_trop_window=1,
-        natrl_forest_biomass_window=np.ma.array([0.5]),
-        deadwood_2000_output=np.ma.array([1]),
-        litter_2000_output=np.ma.array([1])
-    )
-    assert result == (np.ma.array([1.0047]), np.ma.array([1.0074]))
+from ...carbon_pools.create_carbon_pools import create_deadwood_litter, deadwood_litter_equations
 
 
 def test_deadwood_litter_equations_can_be_called():
@@ -86,12 +17,12 @@ def test_deadwood_litter_equations_can_be_called():
 
 def test_deadwood_litter_equations_return_zero_deadwood_for_zero_biomass():
     deadwood, _ = deadwood_litter_equations(
-    bor_tem_trop_window=np.zeros((1, 1), dtype='float32'),
-    deadwood_2000_output=np.zeros((1, 1), dtype='float32'),
-    elevation_window=np.zeros((1, 1), dtype='float32'),
-    litter_2000_output=np.zeros((1, 1), dtype='float32'),
-    natrl_forest_biomass_window=np.zeros((1, 1), dtype='float32'),
-    precip_window=np.zeros((1, 1), dtype='float32')
+        bor_tem_trop_window=np.zeros((1, 1), dtype='float32'),
+        deadwood_2000_output=np.zeros((1, 1), dtype='float32'),
+        elevation_window=np.zeros((1, 1), dtype='float32'),
+        litter_2000_output=np.zeros((1, 1), dtype='float32'),
+        natrl_forest_biomass_window=np.zeros((1, 1), dtype='float32'),
+        precip_window=np.zeros((1, 1), dtype='float32')
     )
     assert deadwood == np.array([0.])
 
@@ -106,3 +37,27 @@ def test_deadwood_litter_equations_return_zero_litter_for_zero_biomass():
         precip_window=np.zeros((1, 1), dtype='float32')
     )
     assert litter == np.array([0.])
+
+
+def test_deadwood_litter_equations_return_zero_deadwood__tropical_low_elev_low_precip():
+    deadwood, _ = deadwood_litter_equations(
+        bor_tem_trop_window=np.array([1], dtype='float32'),
+        deadwood_2000_output=np.array([0], dtype='float32'),
+        elevation_window=np.array([1], dtype='float32'),
+        litter_2000_output=np.array([0], dtype='float32'),
+        natrl_forest_biomass_window=np.array([1], dtype='float32'),
+        precip_window=np.array([1], dtype='float32')
+    )
+    assert deadwood == np.array([0.02])
+
+
+def test_deadwood_litter_equations_return_zero_litter__tropical_low_elev_low_precip():
+    _, litter = deadwood_litter_equations(
+        bor_tem_trop_window=np.array([1], dtype='float32'),
+        deadwood_2000_output=np.array([0], dtype='float32'),
+        elevation_window=np.array([1], dtype='float32'),
+        litter_2000_output=np.array([0], dtype='float32'),
+        natrl_forest_biomass_window=np.array([1], dtype='float32'),
+        precip_window=np.array([1], dtype='float32')
+    )
+    assert litter == np.array([0.04])

--- a/test/carbon_pools/test_carbon_pools.py
+++ b/test/carbon_pools/test_carbon_pools.py
@@ -155,3 +155,12 @@ def test_deadwood_litter_equations_return_zero_litter__non_tropical_any_elev_any
         precip_window=np.array([1], dtype='float32')
     )
     assert litter == np.array([1.48], dtype='float32')
+
+
+def test_create_deadwood_litter():
+    result = create_deadwood_litter(
+        tile_id="00N_000E",
+        mang_deadwood_AGB_ratio= {'1': 0.5, '2': 0.4, '3': 0.2, '4': 100},
+        mang_litter_AGB_ratio={'1': 0.8, '2': 0.7, '3': 0.6, '4': 100},
+        carbon_pool_extent=['loss']
+    )


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Make sure you are requesting to pull a topic/feature/bugfix branch (right side). Don't request your master!
- [x] Make sure you are making a pull request against the develop branch (left side). Also you should start your branch off our develop.
- [x] Check the commit's or even all commits' message styles matches our requested structure.
- [x] Check your code additions will fail neither code linting checks nor unit test.

## Pull request type

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
No useful unit tests in test_carbon_pools.py before.

## What is the new behavior?

- Created some tests for deadwood and litter carbon pool generation. Uses different combinations of precipitation, elevation, and climate domain to make sure that deadwood and litter arithmetic is being done correctly. It's not testing rasterio functionality at all, just the basic numpy arithmetic. 

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

In order to make this deadwood/litter testing work, I needed to refactor the numpy arithmetic out of the deadwood/litter creation function. Gary Tempus showed me how to do that, as well as how to write the initial tests. I ran mp_create_carbon_pools after making these changes to make sure that the deadwood and litter rasters were still coming out correctly. 
