### PR TITLE
Changed global warming potential (GWP) factors for methane and nitrou…

### DIFF
--- a/emissions/cpp_util/constants.h
+++ b/emissions/cpp_util/constants.h
@@ -7,9 +7,9 @@ namespace constants
     // per https://www.learncpp.com/cpp-tutorial/global-constants-and-inline-variables/
     constexpr int model_years {21};    // How many loss years are in the model. Must also be updated in equations.cpp!
 
-    constexpr int CH4_equiv {28};      // The CO2 equivalency (global warming potential) of CH4
+    constexpr int CH4_equiv {27};      // The CO2 equivalency (global warming potential) of CH4, AR6 WG1 Table 7.15
 
-    constexpr int N2O_equiv {265};      // The CO2 equivalency (global warming potential) of N2O
+    constexpr int N2O_equiv {273};      // The CO2 equivalency (global warming potential) of N2O, AR6 WG1 Table 7.15
 
     constexpr float C_to_CO2 {44.0/12.0};       // The conversion of carbon to CO2
 


### PR DESCRIPTION
…s oxide to use AR6 WG1. Ran locally on 00N_000E and it seems fine.

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Make sure you are requesting to pull a topic/feature/bugfix branch (right side). Don't request your master!
- [x] Make sure you are making a pull request against the develop branch (left side). Also you should start your branch off our develop.
- [x] Check the commit's or even all commits' message styles matches our requested structure.
- [x] Check your code additions will fail neither code linting checks nor unit test.

## Pull request type

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
1. Used AR5 global warming potentials for CH4 and N2O.

## What is the new behavior?
1. Switched to AR6 global warming potentials for CH4 and N2O. Using Table 7.15 (pdf p. 95) in chapter 7 of the final AR6 WG1: CH4-non-fossil GWP-100 is 27.0 and N2O GWP-100 is 273

## Does this introduce a breaking change?

- [ ] Yes
- [x] No


## Other information

Ran 00N_000E locally and checked some non-CO2 emissions calculations on test tiles. 
