### PR TITLE
Feature/add soil only emis step

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -64,8 +64,8 @@ RUN cp pg_hba.conf /etc/postgresql/12/main/
 # RUN service postgresql restart
 
 
-# Install missing Python dependencies
-RUN pip3 install -r requirements.txt
+# # Install missing Python dependencies
+# RUN pip3 install -r requirements.txt
 
 # Link gdal libraries
 RUN cd /usr/include && ln -s ./ gdal

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,6 @@
 #Ubuntu 20.04.4 LTS, Python 3.8.10, GDAL 3.4.2
 FROM osgeo/gdal:ubuntu-small-3.4.2
 
-# # Use this if downloading hdf files for burn year analysis
-# FROM osgeo/gdal:ubuntu-full-3.4.2
-
 ENV DIR=/usr/local/app
 ENV TMP=/usr/local/tmp
 ENV TILES=/usr/local/tiles
@@ -64,8 +61,8 @@ RUN cp pg_hba.conf /etc/postgresql/12/main/
 # RUN service postgresql restart
 
 
-# # Install missing Python dependencies
-# RUN pip3 install -r requirements.txt
+# Install missing Python dependencies
+RUN pip3 install -r requirements.txt
 
 # Link gdal libraries
 RUN cd /usr/include && ln -s ./ gdal
@@ -82,13 +79,6 @@ RUN git config --global user.email dagibbs22@gmail.com
 #
 ## Makes sure the latest version of the current branch is downloaded
 #RUN git pull origin model_v_1.2.2
-
-## Compile C++ scripts
-RUN g++ /usr/local/app/emissions/cpp_util/calc_gross_emissions_generic.cpp -o /usr/local/app/emissions/cpp_util/calc_gross_emissions_generic.exe -lgdal
-#    RUN g++ /usr/local/app/emissions/cpp_util/calc_gross_emissions_generic.cpp -o /usr/local/app/emissions/cpp_util/calc_gross_emissions_generic.exe -lgdal && \
-#    g++ /usr/local/app/emissions/cpp_util/calc_gross_emissions_soil_only.cpp -o /usr/local/app/emissions/cpp_util/calc_gross_emissions_soil_only.exe -lgdal && \
-#    g++ /usr/local/app/emissions/cpp_util/calc_gross_emissions_no_shifting_ag.cpp -o /usr/local/app/emissions/cpp_util/calc_gross_emissions_no_shifting_ag.exe -lgdal && \
-#    g++ /usr/local/app/emissions/cpp_util/calc_gross_emissions_convert_to_grassland.cpp -o /usr/local/app/emissions/cpp_util/calc_gross_emissions_convert_to_grassland.exe -lgdal
 
 # Opens the Docker shell
 ENTRYPOINT ["/bin/bash"]

--- a/data_import.bat
+++ b/data_import.bat
@@ -2,11 +2,11 @@
 :: Lines must be uncommented according to the model being imported, e.g., standard, maxgain, soil_only, etc.
 :: David Gibbs, david.gibbs@wri.org
 
-FOR %%I IN (output\carbonflux_20210324_0439\iso\summary\*.csv) DO psql -d flux_model -U postgres -c "\copy standard_iso_summary_20210323 FROM %%I CSV HEADER DELIMITER e'\t'
-FOR %%I IN (output\carbonflux_20210324_0439\iso\change\*.csv) DO psql -d flux_model -U postgres -c "\copy standard_iso_change_20210323 FROM %%I CSV HEADER DELIMITER e'\t'
+FOR %%I IN (output\carbonflux_20220418_1744\iso\summary\*.csv) DO psql -d flux_model -U postgres -c "\copy standard_iso_summary_20220316 FROM %%I CSV HEADER DELIMITER e'\t'
+FOR %%I IN (output\carbonflux_20220418_1744\iso\change\*.csv) DO psql -d flux_model -U postgres -c "\copy standard_iso_change_20220316 FROM %%I CSV HEADER DELIMITER e'\t'
 
-::FOR %%I IN (output\soil_only\iso\summary\*.csv) DO psql -d flux_model -U postgres -c "\copy soil_only_iso_summary_20200904 FROM %%I CSV HEADER DELIMITER e'\t'
-::FOR %%I IN (output\soil_only\iso\change\*.csv) DO psql -d flux_model -U postgres -c "\copy soil_only_iso_change_20200904 FROM %%I CSV HEADER DELIMITER e'\t'
+::FOR %%I IN (output\carbon_sensitivity_soil_only_20210326_0003\iso\summary\*.csv) DO psql -d flux_model -U postgres -c "\copy soil_only_iso_summary_20210324 FROM %%I CSV HEADER DELIMITER e'\t'
+::FOR %%I IN (output\carbon_sensitivity_soil_only_20210326_0003\iso\change\*.csv) DO psql -d flux_model -U postgres -c "\copy soil_only_iso_change_20210324 FROM %%I CSV HEADER DELIMITER e'\t'
 
 ::FOR %%I IN (output\maxgain\iso\summary\*.csv) DO psql -d flux_model -U postgres -c "\copy maxgain_iso_summary_20200921 FROM %%I CSV HEADER DELIMITER e'\t'
 ::FOR %%I IN (output\maxgain\iso\change\*.csv) DO psql -d flux_model -U postgres -c "\copy maxgain_iso_change FROM %%I CSV HEADER DELIMITER e'\t'

--- a/emissions/cpp_util/calc_gross_emissions_generic.cpp
+++ b/emissions/cpp_util/calc_gross_emissions_generic.cpp
@@ -84,6 +84,12 @@ boreal = constants::boreal;
 int soil_emis_period;      // The number of years over which soil emissions are calculated (separate from model years)
 soil_emis_period = constants::soil_emis_period;
 
+float shiftag_flu; // F_lu for shifting agriculture (fraction of soil C not emitted over 20 years)
+shiftag_flu = constants::shiftag_flu;
+
+float urb_flu; // F_lu for urbanization (fraction of soil C not emitted over 20 years)
+urb_flu = constants::urb_flu;
+
 
 // Input files
 // Carbon pools
@@ -655,8 +661,6 @@ for(x=0; x<xsize; x++)
 				Biomass_tCO2e_nofire_CO2_only = non_soil_c * C_to_CO2;
 				Biomass_tCO2e_yesfire_CO2_only = (non_soil_c * C_to_CO2);
                 Biomass_tCO2e_yesfire_non_CO2 = ((non_soil_c / biomass_to_c) * Cf * Gef_CH4 * pow(10,-3) * CH4_equiv) + ((non_soil_c / biomass_to_c) * Cf * Gef_N2O * pow(10,-3) * N2O_equiv);
-				float shiftag_flu;
-				shiftag_flu = 0.72;
 				minsoil = ((soil_data[x]-(soil_data[x] * shiftag_flu))/soil_emis_period) * (model_years-loss_data[x]);
 
 				if (peat_data[x] > 0) // Shifting ag, peat
@@ -955,8 +959,6 @@ for(x=0; x<xsize; x++)
 				Biomass_tCO2e_nofire_CO2_only = non_soil_c * C_to_CO2;
 				Biomass_tCO2e_yesfire_CO2_only = (non_soil_c * C_to_CO2);
 				Biomass_tCO2e_yesfire_non_CO2 = ((non_soil_c / biomass_to_c) * Cf * Gef_CH4 * pow(10,-3) * CH4_equiv) + ((non_soil_c / biomass_to_c) * Cf * Gef_N2O * pow(10,-3) * N2O_equiv);
-				float urb_flu;
-				urb_flu = 0.8;
 				minsoil = ((soil_data[x]-(soil_data[x] * urb_flu))/soil_emis_period) * (model_years-loss_data[x]);
 
                 if (peat_data[x] > 0) // Urbanization, peat

--- a/emissions/cpp_util/calc_gross_emissions_generic.cpp
+++ b/emissions/cpp_util/calc_gross_emissions_generic.cpp
@@ -14,7 +14,7 @@
 // Because emissions are separately output for CO2 and non-CO2 gases (CH4 and N2O), each model endpoint has a CO2-only and
 // a non-CO2 value. These are summed to create a total emissions (all gases) for each pixel.
 // Compile with:
-// c++ ../carbon-budget/emissions/cpp_util/calc_gross_emissions_biomass_soil.cpp -o ../carbon-budget/emissions/cpp_util/calc_gross_emissions_biomass_soil.exe -lgdal
+// c++ /usr/local/app/emissions/cpp_util/calc_gross_emissions_generic.cpp -o /usr/local/app/emissions/cpp_util/calc_gross_emissions_generic.exe -lgdal
 
 
 #include <iostream>

--- a/emissions/cpp_util/calc_gross_emissions_soil_only.cpp
+++ b/emissions/cpp_util/calc_gross_emissions_soil_only.cpp
@@ -16,6 +16,7 @@
 // Compile with:
 // c++ /usr/local/app/emissions/cpp_util/calc_gross_emissions_soil_only.cpp -o /usr/local/app/emissions/cpp_util/calc_gross_emissions_soil_only.exe -lgdal
 
+
 #include <iostream>
 #include <stdio.h>
 #include <stdlib.h>

--- a/emissions/cpp_util/calc_gross_emissions_soil_only.cpp
+++ b/emissions/cpp_util/calc_gross_emissions_soil_only.cpp
@@ -16,7 +16,6 @@
 // Compile with:
 // c++ /usr/local/app/emissions/cpp_util/calc_gross_emissions_soil_only.cpp -o /usr/local/app/emissions/cpp_util/calc_gross_emissions_soil_only.exe -lgdal
 
-
 #include <iostream>
 #include <stdio.h>
 #include <stdlib.h>
@@ -41,7 +40,6 @@
 
 using namespace std;
 
-//to compile:  c++ calc_gross_emissions.cpp -o calc_gross_emissions.exe -lgdal
 int main(int argc, char* argv[])
 {
 // If code is run other than <program name> <tile id> , it will raise this error.
@@ -354,19 +352,44 @@ float out_data20[xsize];
 for (y=0; y<ysize; y++)
 {
 
-INBAND1->RasterIO(GF_Read, 0, y, xsize, 1, agc_data, xsize, 1, GDT_Float32, 0, 0);
-INBAND2->RasterIO(GF_Read, 0, y, xsize, 1, bgc_data, xsize, 1, GDT_Float32, 0, 0);
-INBAND3->RasterIO(GF_Read, 0, y, xsize, 1, drivermodel_data, xsize, 1, GDT_Float32, 0, 0);
-INBAND4->RasterIO(GF_Read, 0, y, xsize, 1, loss_data, xsize, 1, GDT_Float32, 0, 0);
-INBAND5->RasterIO(GF_Read, 0, y, xsize, 1, peat_data, xsize, 1, GDT_Float32, 0, 0);
-INBAND6->RasterIO(GF_Read, 0, y, xsize, 1, burn_data, xsize, 1, GDT_Float32, 0, 0);
-INBAND7->RasterIO(GF_Read, 0, y, xsize, 1, ifl_primary_data, xsize, 1, GDT_Float32, 0, 0);
-INBAND8->RasterIO(GF_Read, 0, y, xsize, 1, ecozone_data, xsize, 1, GDT_Float32, 0, 0);
-INBAND9->RasterIO(GF_Read, 0, y, xsize, 1, climate_data, xsize, 1, GDT_Float32, 0, 0);
-INBAND10->RasterIO(GF_Read, 0, y, xsize, 1, dead_data, xsize, 1, GDT_Float32, 0, 0);
-INBAND11->RasterIO(GF_Read, 0, y, xsize, 1, litter_data, xsize, 1, GDT_Float32, 0, 0);
-INBAND12->RasterIO(GF_Read, 0, y, xsize, 1, soil_data, xsize, 1, GDT_Float32, 0, 0);
-INBAND13->RasterIO(GF_Read, 0, y, xsize, 1, plant_data, xsize, 1, GDT_Float32, 0, 0);
+// The following RasterIO reads (and the RasterIO writes at the end) produced compile warnings about unused results
+// (warning: ignoring return value of 'CPLErr GDALRasterBand::RasterIO(GDALRWFlag, int, int, int, int, void*, int, int, GDALDataType, GSpacing, GSpacing, GDALRasterIOExtraArg*)', declared with attribute warn_unused_result [-Wunused-result]).
+// I asked how to handle or silence the warnings at https://stackoverflow.com/questions/72410931/how-to-handle-warn-unused-result-wunused-result/72410978#72410978.
+// The code below handles the warnings by directing them to arguments, which are then checked.
+// For cerr instead of std::err: https://www.geeksforgeeks.org/cerr-standard-error-stream-object-in-cpp/
+
+// Error code returned by each line saved as their own argument
+CPLErr errcodeIn1 = INBAND1->RasterIO(GF_Read, 0, y, xsize, 1, agc_data, xsize, 1, GDT_Float32, 0, 0);
+CPLErr errcodeIn2 = INBAND2->RasterIO(GF_Read, 0, y, xsize, 1, bgc_data, xsize, 1, GDT_Float32, 0, 0);
+CPLErr errcodeIn3 = INBAND3->RasterIO(GF_Read, 0, y, xsize, 1, drivermodel_data, xsize, 1, GDT_Float32, 0, 0);
+CPLErr errcodeIn4 = INBAND4->RasterIO(GF_Read, 0, y, xsize, 1, loss_data, xsize, 1, GDT_Float32, 0, 0);
+CPLErr errcodeIn5 = INBAND5->RasterIO(GF_Read, 0, y, xsize, 1, peat_data, xsize, 1, GDT_Float32, 0, 0);
+CPLErr errcodeIn6 = INBAND6->RasterIO(GF_Read, 0, y, xsize, 1, burn_data, xsize, 1, GDT_Float32, 0, 0);
+CPLErr errcodeIn7 = INBAND7->RasterIO(GF_Read, 0, y, xsize, 1, ifl_primary_data, xsize, 1, GDT_Float32, 0, 0);
+CPLErr errcodeIn8 = INBAND8->RasterIO(GF_Read, 0, y, xsize, 1, ecozone_data, xsize, 1, GDT_Float32, 0, 0);
+CPLErr errcodeIn9 = INBAND9->RasterIO(GF_Read, 0, y, xsize, 1, climate_data, xsize, 1, GDT_Float32, 0, 0);
+CPLErr errcodeIn10 = INBAND10->RasterIO(GF_Read, 0, y, xsize, 1, dead_data, xsize, 1, GDT_Float32, 0, 0);
+CPLErr errcodeIn11 = INBAND11->RasterIO(GF_Read, 0, y, xsize, 1, litter_data, xsize, 1, GDT_Float32, 0, 0);
+CPLErr errcodeIn12 = INBAND12->RasterIO(GF_Read, 0, y, xsize, 1, soil_data, xsize, 1, GDT_Float32, 0, 0);
+CPLErr errcodeIn13 = INBAND13->RasterIO(GF_Read, 0, y, xsize, 1, plant_data, xsize, 1, GDT_Float32, 0, 0);
+
+// Number of input files
+int inSize = 13;
+
+// Array of error codes returned from each input
+CPLErr errcodeInArray [inSize] = {errcodeIn1, errcodeIn2, errcodeIn3, errcodeIn4, errcodeIn5, errcodeIn6, errcodeIn7,
+errcodeIn8, errcodeIn9, errcodeIn10, errcodeIn11, errcodeIn12, errcodeIn13};
+
+// Iterates through the input error codes to make sure that the error code is acceptable
+int j;
+
+for (j=0; j<inSize; j++)
+{
+    if (errcodeInArray[j] != 0) {
+        cerr << "rasterIO failed!\n";
+        exit(1);
+    }
+}
 
 for(x=0; x<xsize; x++)
 
@@ -1169,16 +1192,41 @@ for(x=0; x<xsize; x++)
 		}
     }
 
-OUTBAND1->RasterIO( GF_Write, 0, y, xsize, 1, out_data1, xsize, 1, GDT_Float32, 0, 0 );
-OUTBAND2->RasterIO( GF_Write, 0, y, xsize, 1, out_data2, xsize, 1, GDT_Float32, 0, 0 );
-OUTBAND3->RasterIO( GF_Write, 0, y, xsize, 1, out_data3, xsize, 1, GDT_Float32, 0, 0 );
-OUTBAND4->RasterIO( GF_Write, 0, y, xsize, 1, out_data4, xsize, 1, GDT_Float32, 0, 0 );
-OUTBAND5->RasterIO( GF_Write, 0, y, xsize, 1, out_data5, xsize, 1, GDT_Float32, 0, 0 );
-OUTBAND6->RasterIO( GF_Write, 0, y, xsize, 1, out_data6, xsize, 1, GDT_Float32, 0, 0 );
-OUTBAND10->RasterIO( GF_Write, 0, y, xsize, 1, out_data10, xsize, 1, GDT_Float32, 0, 0 );
-OUTBAND11->RasterIO( GF_Write, 0, y, xsize, 1, out_data11, xsize, 1, GDT_Float32, 0, 0 );
-OUTBAND12->RasterIO( GF_Write, 0, y, xsize, 1, out_data12, xsize, 1, GDT_Float32, 0, 0 );
-OUTBAND20->RasterIO( GF_Write, 0, y, xsize, 1, out_data20, xsize, 1, GDT_Float32, 0, 0 );
+// The following RasterIO writes (and the RasterIO reads at the start) produced compile warnings about unused results
+// (warning: ignoring return value of 'CPLErr GDALRasterBand::RasterIO(GDALRWFlag, int, int, int, int, void*, int, int, GDALDataType, GSpacing, GSpacing, GDALRasterIOExtraArg*)', declared with attribute warn_unused_result [-Wunused-result]).
+// I asked how to handle or silence the warnings at https://stackoverflow.com/questions/72410931/how-to-handle-warn-unused-result-wunused-result/72410978#72410978.
+// The code below handles the warnings by directing them to arguments, which are then checked.
+// For cerr instead of std::err: https://www.geeksforgeeks.org/cerr-standard-error-stream-object-in-cpp/
+
+// Error code returned by each line saved as their own argument
+CPLErr errcodeOut1 = OUTBAND1->RasterIO( GF_Write, 0, y, xsize, 1, out_data1, xsize, 1, GDT_Float32, 0, 0 );
+CPLErr errcodeOut2 = OUTBAND2->RasterIO( GF_Write, 0, y, xsize, 1, out_data2, xsize, 1, GDT_Float32, 0, 0 );
+CPLErr errcodeOut3 = OUTBAND3->RasterIO( GF_Write, 0, y, xsize, 1, out_data3, xsize, 1, GDT_Float32, 0, 0 );
+CPLErr errcodeOut4 = OUTBAND4->RasterIO( GF_Write, 0, y, xsize, 1, out_data4, xsize, 1, GDT_Float32, 0, 0 );
+CPLErr errcodeOut5 = OUTBAND5->RasterIO( GF_Write, 0, y, xsize, 1, out_data5, xsize, 1, GDT_Float32, 0, 0 );
+CPLErr errcodeOut6 = OUTBAND6->RasterIO( GF_Write, 0, y, xsize, 1, out_data6, xsize, 1, GDT_Float32, 0, 0 );
+CPLErr errcodeOut10 = OUTBAND10->RasterIO( GF_Write, 0, y, xsize, 1, out_data10, xsize, 1, GDT_Float32, 0, 0 );
+CPLErr errcodeOut11 = OUTBAND11->RasterIO( GF_Write, 0, y, xsize, 1, out_data11, xsize, 1, GDT_Float32, 0, 0 );
+CPLErr errcodeOut12 = OUTBAND12->RasterIO( GF_Write, 0, y, xsize, 1, out_data12, xsize, 1, GDT_Float32, 0, 0 );
+CPLErr errcodeOut20 = OUTBAND20->RasterIO( GF_Write, 0, y, xsize, 1, out_data20, xsize, 1, GDT_Float32, 0, 0 );
+
+// Number of output files
+int outSize = 10;
+
+// Array of error codes returned from each output
+CPLErr errcodeOutArray [outSize] = {errcodeOut1, errcodeOut2, errcodeOut3, errcodeOut4, errcodeOut5, errcodeOut6,
+errcodeOut10, errcodeOut11, errcodeOut12, errcodeOut20};
+
+// Iterates through the output error codes to make sure that the error code is acceptable
+int k;
+
+for (k=0; k<outSize; k++)
+{
+    if (errcodeOutArray[k] != 0) {
+        cerr << "rasterIO failed!\n";
+        exit(1);
+    }
+}
 }
 
 GDALClose(INGDAL1);

--- a/emissions/cpp_util/calc_gross_emissions_soil_only.cpp
+++ b/emissions/cpp_util/calc_gross_emissions_soil_only.cpp
@@ -424,7 +424,7 @@ for(x=0; x<xsize; x++)
 		float outdata10 = 0;  // all drivers, all gases
 		float outdata11 = 0;  // all drivers, CO2 only
 		float outdata12 = 0;  // all drivers, non-CO2
-		short int  outdata20 = 0;  // flowchart node
+		short int outdata20 = 0;  // flowchart node
 
         // Only evaluates pixels that have loss and carbon. By definition, all pixels with carbon are in the model extent.
 		if (loss_data[x] > 0 && agc_data[x] > 0)
@@ -678,7 +678,7 @@ for(x=0; x<xsize; x++)
 						        outdata20 = 231;
 						    }
 						}
-
+                    }
 				}
 				if (peat_data[x] == 0)// Shifting ag, not peat
 				{

--- a/emissions/cpp_util/calc_gross_emissions_soil_only.cpp
+++ b/emissions/cpp_util/calc_gross_emissions_soil_only.cpp
@@ -83,6 +83,12 @@ boreal = constants::boreal;
 int soil_emis_period;      // The number of years over which soil emissions are calculated (separate from model years)
 soil_emis_period = constants::soil_emis_period;
 
+float shiftag_flu; // F_lu for shifting agriculture (fraction of soil C not emitted over 20 years)
+shiftag_flu = constants::shiftag_flu;
+
+float urb_flu; // F_lu for urbanization (fraction of soil C not emitted over 20 years)
+urb_flu = constants::urb_flu;
+
 
 // Input files
 // Carbon pools use the standard names for this sensitivity analysis
@@ -314,7 +320,7 @@ OUTBAND12 = OUTGDAL12->GetRasterBand(1);
 OUTBAND12->SetNoDataValue(0);
 
 // Decision tree node
-OUTGDAL20 = OUTDRIVER->Create( out_name20.c_str(), xsize, ysize, 1, GDT_Float32, papszOptions );
+OUTGDAL20 = OUTDRIVER->Create( out_name20.c_str(), xsize, ysize, 1, GDT_UInt16, papszOptions );
 OUTGDAL20->SetGeoTransform(adfGeoTransform); OUTGDAL20->SetProjection(OUTPRJ);
 OUTBAND20 = OUTGDAL20->GetRasterBand(1);
 OUTBAND20->SetNoDataValue(0);
@@ -346,7 +352,7 @@ float out_data6[xsize];
 float out_data10[xsize];
 float out_data11[xsize];
 float out_data12[xsize];
-float out_data20[xsize];
+short int out_data20[xsize];
 
 // Loop over the y coordinates, then the x coordinates
 for (y=0; y<ysize; y++)
@@ -418,7 +424,7 @@ for(x=0; x<xsize; x++)
 		float outdata10 = 0;  // all drivers, all gases
 		float outdata11 = 0;  // all drivers, CO2 only
 		float outdata12 = 0;  // all drivers, non-CO2
-		float outdata20 = 0;  // flowchart node
+		short int  outdata20 = 0;  // flowchart node
 
         // Only evaluates pixels that have loss and carbon. By definition, all pixels with carbon are in the model extent.
 		if (loss_data[x] > 0 && agc_data[x] > 0)
@@ -630,8 +636,6 @@ for(x=0; x<xsize; x++)
 //				Biomass_tCO2e_nofire_CO2_only = non_soil_c * C_to_CO2;
 //				Biomass_tCO2e_yesfire_CO2_only = (non_soil_c * C_to_CO2);
 //              Biomass_tCO2e_yesfire_non_CO2 = ((non_soil_c / biomass_to_c) * Cf * Gef_CH4 * pow(10,-3) * CH4_equiv) + ((non_soil_c / biomass_to_c) * Cf * Gef_N2O * pow(10,-3) * N2O_equiv);
-				float shiftag_flu;
-				shiftag_flu = 0.72;
 				minsoil = ((soil_data[x]-(soil_data[x] * shiftag_flu))/soil_emis_period) * (model_years-loss_data[x]);
 
 				if (peat_data[x] > 0) // Shifting ag, peat
@@ -674,7 +678,7 @@ for(x=0; x<xsize; x++)
 						        outdata20 = 231;
 						    }
 						}
-					}
+
 				}
 				if (peat_data[x] == 0)// Shifting ag, not peat
 				{
@@ -900,8 +904,6 @@ for(x=0; x<xsize; x++)
 //				Biomass_tCO2e_nofire_CO2_only = non_soil_c * C_to_CO2;
 //				Biomass_tCO2e_yesfire_CO2_only = (non_soil_c * C_to_CO2);
 //				Biomass_tCO2e_yesfire_non_CO2 = ((non_soil_c / biomass_to_c) * Cf * Gef_CH4 * pow(10,-3) * CH4_equiv) + ((non_soil_c / biomass_to_c) * Cf * Gef_N2O * pow(10,-3) * N2O_equiv);
-				float urb_flu;
-				urb_flu = 0.8;
 				minsoil = ((soil_data[x]-(soil_data[x] * urb_flu))/soil_emis_period) * (model_years-loss_data[x]);
 
                 if (peat_data[x] > 0) // Urbanization, peat
@@ -1208,7 +1210,7 @@ CPLErr errcodeOut6 = OUTBAND6->RasterIO( GF_Write, 0, y, xsize, 1, out_data6, xs
 CPLErr errcodeOut10 = OUTBAND10->RasterIO( GF_Write, 0, y, xsize, 1, out_data10, xsize, 1, GDT_Float32, 0, 0 );
 CPLErr errcodeOut11 = OUTBAND11->RasterIO( GF_Write, 0, y, xsize, 1, out_data11, xsize, 1, GDT_Float32, 0, 0 );
 CPLErr errcodeOut12 = OUTBAND12->RasterIO( GF_Write, 0, y, xsize, 1, out_data12, xsize, 1, GDT_Float32, 0, 0 );
-CPLErr errcodeOut20 = OUTBAND20->RasterIO( GF_Write, 0, y, xsize, 1, out_data20, xsize, 1, GDT_Float32, 0, 0 );
+CPLErr errcodeOut20 = OUTBAND20->RasterIO( GF_Write, 0, y, xsize, 1, out_data20, xsize, 1, GDT_UInt16, 0, 0 );
 
 // Number of output files
 int outSize = 10;

--- a/emissions/cpp_util/constants.h
+++ b/emissions/cpp_util/constants.h
@@ -23,6 +23,10 @@ namespace constants
 
     constexpr int soil_emis_period {20};      // The number of years over which soil emissions are calculated (separate from model years)
 
+    constexpr float shiftag_flu {0.72}; // F_lu for shifting agriculture (fraction of soil C not emitted over 20 years)
+
+    constexpr float urb_flu {0.80}; // F_lu for urbanization (fraction of soil C not emitted over 20 years)
+
     // Input and output variable patterns
     // per https://stackoverflow.com/questions/27123306/is-it-possible-to-use-stdstring-in-a-constexpr
     // Inputs

--- a/emissions/mp_calculate_gross_emissions.py
+++ b/emissions/mp_calculate_gross_emissions.py
@@ -21,7 +21,7 @@ Emissions from all drivers is also output as emissions due to CO2 only and emiss
 The other output shows which branch of the decision tree that determines the emissions equation applies to each pixel.
 These codes are summarized in carbon-budget/emissions/node_codes.txt
 
-python -m emissions.mp_calculate_gross_emissions -t std -p biomass_soil -l all -nu
+python -m emissions.mp_calculate_gross_emissions -t std -p biomass_soil -l ooN_000E -nu
 """
 
 import argparse
@@ -123,42 +123,52 @@ def mp_calculate_gross_emissions(tile_id_list, emitted_pools):
             if os.path.exists(f'{cn.c_emis_compile_dst}/calc_gross_emissions_{cn.SENSIT_TYPE}.exe'):
                 uu.print_log(f'C++ for {cn.SENSIT_TYPE} already compiled.')
             else:
-                uu.exception_log(f'Must compile {cn.SENSIT_TYPE} model C++...')
+                uu.print_log(f'Compiled {cn.SENSIT_TYPE} model C++ not found. Compiling...')
+                cmd = ['c++', f'/usr/local/app/emissions/cpp_util/calc_gross_emissions_{cn.SENSIT_TYPE}.cpp',
+                       '-o', f'/usr/local/app/emissions/cpp_util/calc_gross_emissions_{cn.SENSIT_TYPE}.exe', '-lgdal']
+                uu.log_subprocess_output_full(cmd)
         else:
             if os.path.exists(f'{cn.c_emis_compile_dst}/calc_gross_emissions_generic.exe'):
                 uu.print_log('C++ for generic emissions already compiled.')
             else:
-                uu.exception_log('Must compile generic emissions C++...')
+                uu.print_log(f'Compiling generic model C++ not found. Compiling...')
+                cmd = ['c++', f'/usr/local/app/emissions/cpp_util/calc_gross_emissions_generic.cpp',
+                       '-o', f'/usr/local/app/emissions/cpp_util/calc_gross_emissions_generic.exe', '-lgdal']
+                uu.log_subprocess_output_full(cmd)
 
     elif (emitted_pools == 'soil_only') & (cn.SENSIT_TYPE == 'std'):
+
+        # Output file directories for soil_only. Must be in same order as output pattern directories.
+        output_dir_list = [cn.gross_emis_commod_soil_only_dir,
+                           cn.gross_emis_shifting_ag_soil_only_dir,
+                           cn.gross_emis_forestry_soil_only_dir,
+                           cn.gross_emis_wildfire_soil_only_dir,
+                           cn.gross_emis_urban_soil_only_dir,
+                           cn.gross_emis_no_driver_soil_only_dir,
+                           cn.gross_emis_all_gases_all_drivers_soil_only_dir,
+                           cn.gross_emis_co2_only_all_drivers_soil_only_dir,
+                           cn.gross_emis_non_co2_all_drivers_soil_only_dir,
+                           cn.gross_emis_nodes_soil_only_dir]
+
+        output_pattern_list = [cn.pattern_gross_emis_commod_soil_only,
+                               cn.pattern_gross_emis_shifting_ag_soil_only,
+                               cn.pattern_gross_emis_forestry_soil_only,
+                               cn.pattern_gross_emis_wildfire_soil_only,
+                               cn.pattern_gross_emis_urban_soil_only,
+                               cn.pattern_gross_emis_no_driver_soil_only,
+                               cn.pattern_gross_emis_all_gases_all_drivers_soil_only,
+                               cn.pattern_gross_emis_co2_only_all_drivers_soil_only,
+                               cn.pattern_gross_emis_non_co2_all_drivers_soil_only,
+                               cn.pattern_gross_emis_nodes_soil_only]
+
         if os.path.exists(f'{cn.c_emis_compile_dst}/calc_gross_emissions_soil_only.exe'):
             uu.print_log('C++ for soil_only already compiled.')
 
-            # Output file directories for soil_only. Must be in same order as output pattern directories.
-            output_dir_list = [cn.gross_emis_commod_soil_only_dir,
-                               cn.gross_emis_shifting_ag_soil_only_dir,
-                               cn.gross_emis_forestry_soil_only_dir,
-                               cn.gross_emis_wildfire_soil_only_dir,
-                               cn.gross_emis_urban_soil_only_dir,
-                               cn.gross_emis_no_driver_soil_only_dir,
-                               cn.gross_emis_all_gases_all_drivers_soil_only_dir,
-                               cn.gross_emis_co2_only_all_drivers_soil_only_dir,
-                               cn.gross_emis_non_co2_all_drivers_soil_only_dir,
-                               cn.gross_emis_nodes_soil_only_dir]
-
-            output_pattern_list = [cn.pattern_gross_emis_commod_soil_only,
-                                   cn.pattern_gross_emis_shifting_ag_soil_only,
-                                   cn.pattern_gross_emis_forestry_soil_only,
-                                   cn.pattern_gross_emis_wildfire_soil_only,
-                                   cn.pattern_gross_emis_urban_soil_only,
-                                   cn.pattern_gross_emis_no_driver_soil_only,
-                                   cn.pattern_gross_emis_all_gases_all_drivers_soil_only,
-                                   cn.pattern_gross_emis_co2_only_all_drivers_soil_only,
-                                   cn.pattern_gross_emis_non_co2_all_drivers_soil_only,
-                                   cn.pattern_gross_emis_nodes_soil_only]
-
         else:
-            uu.exception_log('Must compile soil_only C++...')
+            uu.print_log(f'Compiled soil_only model C++ not found. Compiling...')
+            cmd = ['c++', f'/usr/local/app/emissions/cpp_util/calc_gross_emissions_soil_only.cpp',
+                   '-o', f'/usr/local/app/emissions/cpp_util/calc_gross_emissions_soil_only.exe', '-lgdal']
+            uu.log_subprocess_output_full(cmd)
 
     else:
         uu.exception_log('Pool and/or sensitivity analysis option not valid')

--- a/emissions/mp_calculate_gross_emissions.py
+++ b/emissions/mp_calculate_gross_emissions.py
@@ -10,7 +10,7 @@ c++ /usr/local/app/emissions/cpp_util/calc_gross_emissions_generic.cpp -o /usr/l
 calc_gross_emissions_generic.exe should appear in the directory.
 For the sensitivity analyses that use a different gross emissions C++ script (currently, soil_only, no_shifting_ag,
 and convert_to_grassland), do:
-c++ /usr/local/app/emissions/cpp_util/calc_gross_emissions_<sensit_type>.cpp -o /usr/local/app/emissions/cpp_util/calc_gross_emissions_<sensit_type>.exe -lgdal
+c++  /usr/local/app/carbon-budget/emissions/cpp_util/calc_gross_emissions_<sensit_type>.cpp -o  /usr/local/app/emissions/cpp_util/calc_gross_emissions_<sensit_type>.exe -lgdal
 Run by typing python -m emissions.mp_calculate_gross_emissions -p [POOL_OPTION] -t [MODEL_TYPE] -l [TILE_LIST] -d [RUN_DATE]
 The Python script will call the compiled C++ code as needed.
 The other C++ scripts (equations.cpp and flu_val.cpp) do not need to be compiled separately.

--- a/readme.md
+++ b/readme.md
@@ -224,7 +224,7 @@ they are run very infrequently.
 | Argument | Short argument | Required/Optional | Relevant stage | Description | 
 | -------- | ----- | ----------- | ------- | ------ |
 | `model-type` | `-t` | Required | All | Standard model (`std`) or a sensitivity analysis. Refer to `constants_and_names.py` for valid list of sensitivity analyses. |
-| `stages` | `-s` | Required | All | The model stage at which the model should start. `all` will run the following stages in this order: model_extent, forest_age_category_IPCC, annual_removals_IPCC, annual_removals_all_forest_types, gain_year_count, gross_removals_all_forest_types, carbon_pools, gross_emissions, net_flux, aggregate, create_supplementary_outputs |
+| `stages` | `-s` | Required | All | The model stage at which the model should start. `all` will run the following stages in this order: model_extent, forest_age_category_IPCC, annual_removals_IPCC, annual_removals_all_forest_types, gain_year_count, gross_removals_all_forest_types, carbon_pools, gross_emissions_all_pools, net_flux, aggregate, create_supplementary_outputs, gross_emissions_biomass_soil |
 | `run-through` | `-r` | Optional | All | If activated, run stage provided in `stages` argument and all following stages. Otherwise, run only stage in `stages` argument. Activated with flag. |
 | `run-date` | `-d` | Required | All | Date of run. Must be format YYYYMMDD. This sets the output folder in s3. |
 | `tile-id-list` | `-l` | Required | All | List of tile ids to use in the model. Should be of form 00N_110E or 00N_110E,00N_120E or all |

--- a/run_full_model.py
+++ b/run_full_model.py
@@ -63,8 +63,8 @@ def main ():
     # List of possible model stages to run (not including mangrove and planted forest stages)
     model_stages = ['all', 'model_extent', 'forest_age_category_IPCC', 'annual_removals_IPCC',
                     'annual_removals_all_forest_types', 'gain_year_count', 'gross_removals_all_forest_types',
-                    'carbon_pools', 'gross_emissions',
-                    'net_flux', 'aggregate', 'create_supplementary_outputs']
+                    'carbon_pools', 'gross_emissions_biomass_soil',
+                    'net_flux', 'aggregate', 'create_supplementary_outputs, gross_emissions_soil_only']
 
 
     # The argument for what kind of model run is being done: standard conditions or a sensitivity analysis run
@@ -165,30 +165,30 @@ def main ():
 
     # Checks if the correct c++ script has been compiled for the pool option selected.
     # Does this up front so that the user is prompted to compile the C++ before the script starts running, if necessary.
-    if 'gross_emissions' in actual_stages:
+    if 'gross_emissions_biomass_soil' in actual_stages:
 
-        if cn.EMITTED_POOLS == 'biomass_soil':
-            # Some sensitivity analyses have specific gross emissions scripts.
-            # The rest of the sensitivity analyses and the standard model can all use the same, generic gross emissions script.
-            if cn.SENSIT_TYPE in ['no_shifting_ag', 'convert_to_grassland']:
-                if os.path.exists(f'{cn.c_emis_compile_dst}/calc_gross_emissions_{cn.SENSIT_TYPE}.exe'):
-                    uu.print_log(f'C++ for {cn.SENSIT_TYPE} already compiled.')
-                else:
-                    uu.exception_log(f'Must compile standard {cn.SENSIT_TYPE} model C++...')
+        # Some sensitivity analyses have specific gross emissions scripts.
+        # The rest of the sensitivity analyses and the standard model can all use the same, generic gross emissions script.
+        if cn.SENSIT_TYPE in ['no_shifting_ag', 'convert_to_grassland']:
+            if os.path.exists(f'{cn.c_emis_compile_dst}/calc_gross_emissions_{cn.SENSIT_TYPE}.exe'):
+                uu.print_log(f'C++ for {cn.SENSIT_TYPE} already compiled.')
             else:
-                if os.path.exists(f'{cn.c_emis_compile_dst}/calc_gross_emissions_generic.exe'):
-                    uu.print_log('C++ for generic emissions already compiled.')
-                else:
-                    uu.exception_log('Must compile generic emissions C++...')
-
-        elif (cn.EMITTED_POOLS == 'soil_only') & (cn.SENSIT_TYPE == 'std'):
-            if os.path.exists(f'{cn.c_emis_compile_dst}/calc_gross_emissions_soil_only.exe'):
+                uu.exception_log(f'Must compile standard {cn.SENSIT_TYPE} model C++...')
+        else:
+            if os.path.exists(f'{cn.c_emis_compile_dst}/calc_gross_emissions_generic.exe'):
                 uu.print_log('C++ for generic emissions already compiled.')
             else:
-                uu.exception_log('Must compile soil_only C++...')
+                uu.exception_log('Must compile generic emissions C++...')
+    else:
+        uu.exception_log('Pool and/or sensitivity analysis option not valid for gross emissions')
 
+    if (cn.EMITTED_POOLS == 'soil_only') & (cn.SENSIT_TYPE == 'std'):
+        if os.path.exists(f'{cn.c_emis_compile_dst}/calc_gross_emissions_soil_only.exe'):
+            uu.print_log('C++ for generic emissions already compiled.')
         else:
-            uu.exception_log('Pool and/or sensitivity analysis option not valid for gross emissions')
+            uu.exception_log('Must compile soil_only C++...')
+    else:
+        uu.exception_log('Pool and/or sensitivity analysis option not valid for gross emissions')
 
     # Checks whether the canopy cover argument is valid up front.
     if 'aggregate' in actual_stages:

--- a/run_full_model.py
+++ b/run_full_model.py
@@ -15,20 +15,20 @@ Compile C++ emissions module (for standard model and sensitivity analyses that u
 c++ /usr/local/app/emissions/cpp_util/calc_gross_emissions_generic.cpp -o /usr/local/app/emissions/cpp_util/calc_gross_emissions_generic.exe -lgdal
 
 Run 00N_000E in standard model; save intermediate outputs; do upload outputs to s3; run all model stages;
-starting from the beginning; get carbon pools at time of loss; emissions from biomass and soil
-python -m run_full_model -si -t std -s all -r -d 20229999 -l 00N_000E -ce loss -p biomass_soil -tcd 30 -ln "00N_000E test"
+starting from the beginning; get carbon pools at time of loss
+python -m run_full_model -si -t std -s all -r -d 20229999 -l 00N_000E -ce loss -tcd 30 -ln "00N_000E test"
 
 Run 00N_000E in standard model; save intermediate outputs; do not upload outputs to s3; run all model stages;
-starting from the beginning; get carbon pools at time of loss; emissions from biomass and soil; use multiprocessing
-python -m run_full_model -si -t std -s all -r -nu -d 20229999 -l 00N_000E -ce loss -p biomass_soil -tcd 30 -ln "00N_000E test"
+starting from the beginning; get carbon pools at time of loss; use multiprocessing
+python -m run_full_model -si -t std -s all -r -nu -d 20229999 -l 00N_000E -ce loss -tcd 30 -ln "00N_000E test"
 
 Run 00N_000E in standard model; save intermediate outputs; do not upload outputs to s3; run all model stages;
-starting from the beginning; get carbon pools at time of loss; emissions from biomass and soil; use singelprocessing
-python -m run_full_model -si -t std -s all -r -nu -d 20229999 -l 00N_000E -ce loss -p biomass_soil -tcd 30 -sp -ln "00N_000E test"
+starting from the beginning; get carbon pools at time of loss; use singelprocessing
+python -m run_full_model -si -t std -s all -r -nu -d 20229999 -l 00N_000E -ce loss -tcd 30 -sp -ln "00N_000E test"
 
 FULL STANDARD MODEL RUN: Run all tiles in standard model; save intermediate outputs; do upload outputs to s3;
-run all model stages; starting from the beginning; get carbon pools at time of loss; emissions from biomass and soil
-python -m run_full_model -si -t std -s all -r -l all -ce loss -p biomass_soil -tcd 30 -ln "Running all tiles"
+run all model stages; starting from the beginning; get carbon pools at time of loss
+python -m run_full_model -si -t std -s all -r -l all -ce loss -tcd 30 -ln "Running all tiles"
 """
 
 import argparse
@@ -63,8 +63,8 @@ def main ():
     # List of possible model stages to run (not including mangrove and planted forest stages)
     model_stages = ['all', 'model_extent', 'forest_age_category_IPCC', 'annual_removals_IPCC',
                     'annual_removals_all_forest_types', 'gain_year_count', 'gross_removals_all_forest_types',
-                    'carbon_pools', 'gross_emissions_biomass_soil',
-                    'net_flux', 'aggregate', 'create_supplementary_outputs, gross_emissions_soil_only']
+                    'carbon_pools', 'gross_emissions_biomass_soil', 'gross_emissions_soil_only',
+                    'net_flux', 'aggregate', 'create_supplementary_outputs']
 
 
     # The argument for what kind of model run is being done: standard conditions or a sensitivity analysis run
@@ -79,9 +79,7 @@ def main ():
     parser.add_argument('--tile-id-list', '-l', required=True,
                         help='List of tile ids to use in the model. Should be of form 00N_110E or 00N_110E,00N_120E or all.')
     parser.add_argument('--carbon-pool-extent', '-ce', required=False,
-                        help='Time period for which carbon emitted_pools should be calculated: loss, 2000, loss,2000, or 2000,loss')
-    parser.add_argument('--emitted-pools-to-use', '-p', required=False,
-                        help='Options are soil_only or biomass_soil. Former only considers emissions from soil. Latter considers emissions from biomass and soil.')
+                        help='Time period for which carbon pools should be calculated: loss, 2000, loss,2000, or 2000,loss')
     parser.add_argument('--tcd-threshold', '-tcd', required=False, default=cn.canopy_threshold,
                         help='Tree cover density threshold above which pixels will be included in the aggregation. Default is 30.')
     parser.add_argument('--std-net-flux-aggreg', '-sagg', required=False,
@@ -106,7 +104,6 @@ def main ():
     cn.RUN_THROUGH = args.run_through
     cn.RUN_DATE = args.run_date
     cn.CARBON_POOL_EXTENT = args.carbon_pool_extent
-    cn.EMITTED_POOLS = args.emitted_pools_to_use
     cn.THRESH = args.tcd_threshold
     cn.STD_NET_FLUX = args.std_net_flux_aggreg
     cn.INCLUDE_MANGROVES = args.mangroves
@@ -163,33 +160,6 @@ def main ():
     if ('carbon_pools' in actual_stages) & (cn.CARBON_POOL_EXTENT not in ['loss', '2000', 'loss,2000', '2000,loss']):
         uu.exception_log('Invalid carbon_pool_extent input. Please choose loss, 2000, loss,2000 or 2000,loss.')
 
-    # Checks if the correct c++ script has been compiled for the pool option selected.
-    # Does this up front so that the user is prompted to compile the C++ before the script starts running, if necessary.
-    if 'gross_emissions_biomass_soil' in actual_stages:
-
-        # Some sensitivity analyses have specific gross emissions scripts.
-        # The rest of the sensitivity analyses and the standard model can all use the same, generic gross emissions script.
-        if cn.SENSIT_TYPE in ['no_shifting_ag', 'convert_to_grassland']:
-            if os.path.exists(f'{cn.c_emis_compile_dst}/calc_gross_emissions_{cn.SENSIT_TYPE}.exe'):
-                uu.print_log(f'C++ for {cn.SENSIT_TYPE} already compiled.')
-            else:
-                uu.exception_log(f'Must compile standard {cn.SENSIT_TYPE} model C++...')
-        else:
-            if os.path.exists(f'{cn.c_emis_compile_dst}/calc_gross_emissions_generic.exe'):
-                uu.print_log('C++ for generic emissions already compiled.')
-            else:
-                uu.exception_log('Must compile generic emissions C++...')
-    else:
-        uu.exception_log('Pool and/or sensitivity analysis option not valid for gross emissions')
-
-    if (cn.EMITTED_POOLS == 'soil_only') & (cn.SENSIT_TYPE == 'std'):
-        if os.path.exists(f'{cn.c_emis_compile_dst}/calc_gross_emissions_soil_only.exe'):
-            uu.print_log('C++ for generic emissions already compiled.')
-        else:
-            uu.exception_log('Must compile soil_only C++...')
-    else:
-        uu.exception_log('Pool and/or sensitivity analysis option not valid for gross emissions')
-
     # Checks whether the canopy cover argument is valid up front.
     if 'aggregate' in actual_stages:
         if cn.THRESH < 0 or cn.THRESH > 99:
@@ -232,7 +202,7 @@ def main ():
         output_dir_list = [cn.annual_gain_AGC_BGC_natrl_forest_US_dir,
                            cn.stdev_annual_gain_AGC_BGC_natrl_forest_US_dir] + output_dir_list
 
-    # Adds the carbon directories depending on which carbon emitted_pools are being generated: 2000 and/or emissions year
+    # Adds the carbon directories depending on which carbon years are being generated: 2000 and/or emissions year
     if 'carbon_pools' in actual_stages:
         if 'loss' in cn.CARBON_POOL_EXTENT:
             output_dir_list = output_dir_list + [cn.AGC_emis_year_dir, cn.BGC_emis_year_dir,
@@ -244,31 +214,30 @@ def main ():
                                                  cn.deadwood_2000_dir, cn.litter_2000_dir,
                                                  cn.soil_C_full_extent_2000_dir, cn.total_C_2000_dir]
 
-    # Adds the biomass_soil output directories or the soil_only output directories depending on the model run
-    if cn.EMITTED_POOLS == 'biomass_soil':
-        output_dir_list = output_dir_list + [cn.gross_emis_commod_biomass_soil_dir,
-                           cn.gross_emis_shifting_ag_biomass_soil_dir,
-                           cn.gross_emis_forestry_biomass_soil_dir,
-                           cn.gross_emis_wildfire_biomass_soil_dir,
-                           cn.gross_emis_urban_biomass_soil_dir,
-                           cn.gross_emis_no_driver_biomass_soil_dir,
-                           cn.gross_emis_all_gases_all_drivers_biomass_soil_dir,
-                           cn.gross_emis_co2_only_all_drivers_biomass_soil_dir,
-                           cn.gross_emis_non_co2_all_drivers_biomass_soil_dir,
-                           cn.gross_emis_nodes_biomass_soil_dir]
+    # Adds the biomass_soil output directories and the soil_only output directories
+    output_dir_list = output_dir_list + [cn.gross_emis_commod_biomass_soil_dir,
+                       cn.gross_emis_shifting_ag_biomass_soil_dir,
+                       cn.gross_emis_forestry_biomass_soil_dir,
+                       cn.gross_emis_wildfire_biomass_soil_dir,
+                       cn.gross_emis_urban_biomass_soil_dir,
+                       cn.gross_emis_no_driver_biomass_soil_dir,
+                       cn.gross_emis_all_gases_all_drivers_biomass_soil_dir,
+                       cn.gross_emis_co2_only_all_drivers_biomass_soil_dir,
+                       cn.gross_emis_non_co2_all_drivers_biomass_soil_dir,
+                       cn.gross_emis_nodes_biomass_soil_dir]
 
-    else:
-        output_dir_list = output_dir_list + [cn.gross_emis_commod_soil_only_dir,
-                               cn.gross_emis_shifting_ag_soil_only_dir,
-                               cn.gross_emis_forestry_soil_only_dir,
-                               cn.gross_emis_wildfire_soil_only_dir,
-                               cn.gross_emis_urban_soil_only_dir,
-                               cn.gross_emis_no_driver_soil_only_dir,
-                               cn.gross_emis_all_gases_all_drivers_soil_only_dir,
-                               cn.gross_emis_co2_only_all_drivers_soil_only_dir,
-                               cn.gross_emis_non_co2_all_drivers_soil_only_dir,
-                               cn.gross_emis_nodes_soil_only_dir]
+    output_dir_list = output_dir_list + [cn.gross_emis_commod_soil_only_dir,
+                       cn.gross_emis_shifting_ag_soil_only_dir,
+                       cn.gross_emis_forestry_soil_only_dir,
+                       cn.gross_emis_wildfire_soil_only_dir,
+                       cn.gross_emis_urban_soil_only_dir,
+                       cn.gross_emis_no_driver_soil_only_dir,
+                       cn.gross_emis_all_gases_all_drivers_soil_only_dir,
+                       cn.gross_emis_co2_only_all_drivers_soil_only_dir,
+                       cn.gross_emis_non_co2_all_drivers_soil_only_dir,
+                       cn.gross_emis_nodes_soil_only_dir]
 
+    # Adds the net flux output directory
     output_dir_list = output_dir_list + [cn.net_flux_dir]
 
     # Supplementary outputs
@@ -431,7 +400,7 @@ def main ():
         uu.print_log(f':::::Processing time for gross_removals_all_forest_types: {elapsed_time}', "\n", "\n")
 
 
-    # Creates carbon emitted_pools in loss year
+    # Creates carbon pools in loss year
     if 'carbon_pools' in actual_stages:
 
         if not cn.SAVE_INTERMEDIATES:
@@ -469,8 +438,8 @@ def main ():
         uu.print_log(f':::::Processing time for create_carbon_pools: {elapsed_time}', "\n", "\n")
 
 
-    # Creates gross emissions tiles by driver, gas, and all emissions combined
-    if 'gross_emissions' in actual_stages:
+    # Creates gross emissions tiles for biomass+soil by driver, gas, and all emissions combined
+    if 'gross_emissions_biomass_soil' in actual_stages:
 
         if not cn.SAVE_INTERMEDIATES:
 
@@ -503,7 +472,44 @@ def main ():
         uu.print_log(':::::Creating gross emissions tiles')
         start = datetime.datetime.now()
 
-        mp_calculate_gross_emissions(tile_id_list, cn.EMITTED_POOLS)
+        mp_calculate_gross_emissions(tile_id_list, 'biomass_soil')
+
+        end = datetime.datetime.now()
+        elapsed_time = end - start
+        uu.check_storage()
+        uu.print_log(f':::::Processing time for gross_emissions: {elapsed_time}', "\n", "\n")
+
+
+    # Creates gross emissions tiles for biomass+soil by driver, gas, and all emissions combined
+    if 'gross_emissions_soil_only' in actual_stages:
+
+        if not cn.SAVE_INTERMEDIATES:
+
+            uu.print_log(':::::Freeing up memory for gross emissions creation by deleting unneeded tiles')
+            tiles_to_delete = []
+            tiles_to_delete.extend(glob.glob(f'*{cn.pattern_gross_emis_non_co2_all_drivers_biomass_soil}*tif'))
+            tiles_to_delete.extend(glob.glob(f'*{cn.pattern_gross_emis_co2_only_all_drivers_biomass_soil}*tif'))
+            tiles_to_delete.extend(glob.glob(f'*{cn.pattern_gross_emis_commod_biomass_soil}*tif'))
+            tiles_to_delete.extend(glob.glob(f'*{cn.pattern_gross_emis_shifting_ag_biomass_soil}*tif'))
+            tiles_to_delete.extend(glob.glob(f'*{cn.pattern_gross_emis_forestry_biomass_soil}*tif'))
+            tiles_to_delete.extend(glob.glob(f'*{cn.pattern_gross_emis_wildfire_biomass_soil}*tif'))
+            tiles_to_delete.extend(glob.glob(f'*{cn.pattern_gross_emis_urban_biomass_soil}*tif'))
+            tiles_to_delete.extend(glob.glob(f'*{cn.pattern_gross_emis_no_driver_biomass_soil}*tif'))
+            tiles_to_delete.extend(glob.glob(f'*{cn.pattern_gross_emis_nodes_biomass_soil}*tif'))
+            uu.print_log(f'  Deleting {len(tiles_to_delete)} tiles...')
+
+            uu.print_log(tiles_to_delete)
+
+            for tile_to_delete in tiles_to_delete:
+                os.remove(tile_to_delete)
+            uu.print_log(':::::Deleted unneeded tiles')
+
+        uu.check_storage()
+
+        uu.print_log(':::::Creating gross emissions tiles')
+        start = datetime.datetime.now()
+
+        mp_calculate_gross_emissions(tile_id_list, 'soil_only')
 
         end = datetime.datetime.now()
         elapsed_time = end - start
@@ -518,29 +524,16 @@ def main ():
 
             uu.print_log(':::::Freeing up memory for net flux creation by deleting unneeded tiles')
             tiles_to_delete = []
-            tiles_to_delete.extend(glob.glob(f'*{cn.pattern_gross_emis_non_co2_all_drivers_biomass_soil}*tif'))
-            tiles_to_delete.extend(glob.glob(f'*{cn.pattern_gross_emis_co2_only_all_drivers_biomass_soil}*tif'))
-            tiles_to_delete.extend(glob.glob(f'*{cn.pattern_gross_emis_commod_biomass_soil}*tif'))
-            tiles_to_delete.extend(glob.glob(f'*{cn.pattern_gross_emis_shifting_ag_biomass_soil}*tif'))
-            tiles_to_delete.extend(glob.glob(f'*{cn.pattern_gross_emis_forestry_biomass_soil}*tif'))
-            tiles_to_delete.extend(glob.glob(f'*{cn.pattern_gross_emis_wildfire_biomass_soil}*tif'))
-            tiles_to_delete.extend(glob.glob(f'*{cn.pattern_gross_emis_urban_biomass_soil}*tif'))
-            tiles_to_delete.extend(glob.glob(f'*{cn.pattern_gross_emis_no_driver_biomass_soil}*tif'))
-            tiles_to_delete.extend(glob.glob(f'*{cn.pattern_gross_emis_nodes_biomass_soil}*tif'))
-            tiles_to_delete.extend(glob.glob(f'*{cn.pattern_AGC_emis_year}*tif'))
-            tiles_to_delete.extend(glob.glob(f'*{cn.pattern_BGC_emis_year}*tif'))
-            tiles_to_delete.extend(glob.glob(f'*{cn.pattern_deadwood_emis_year_2000}*tif'))
-            tiles_to_delete.extend(glob.glob(f'*{cn.pattern_litter_emis_year_2000}*tif'))
-            tiles_to_delete.extend(glob.glob(f'*{cn.pattern_soil_C_emis_year_2000}*tif'))
-            tiles_to_delete.extend(glob.glob(f'*{cn.pattern_total_C_emis_year}*tif'))
-            tiles_to_delete.extend(glob.glob(f'*{cn.pattern_peat_mask}*tif'))
-            tiles_to_delete.extend(glob.glob(f'*{cn.pattern_ifl_primary}*tif'))
-            tiles_to_delete.extend(glob.glob(f'*{cn.pattern_planted_forest_type_unmasked}*tif'))
-            tiles_to_delete.extend(glob.glob(f'*{cn.pattern_drivers}*tif'))
-            tiles_to_delete.extend(glob.glob(f'*{cn.pattern_climate_zone}*tif'))
-            tiles_to_delete.extend(glob.glob(f'*{cn.pattern_bor_tem_trop_processed}*tif'))
-            tiles_to_delete.extend(glob.glob(f'*{cn.pattern_TCLF_processed}*tif'))
-            tiles_to_delete.extend(glob.glob(f'*{cn.pattern_plant_pre_2000}*tif'))
+            tiles_to_delete.extend(glob.glob(f'*{cn.pattern_gross_emis_all_gases_all_drivers_soil_only}*tif'))
+            tiles_to_delete.extend(glob.glob(f'*{cn.pattern_gross_emis_non_co2_all_drivers_soil_only}*tif'))
+            tiles_to_delete.extend(glob.glob(f'*{cn.pattern_gross_emis_co2_only_all_drivers_soil_only}*tif'))
+            tiles_to_delete.extend(glob.glob(f'*{cn.pattern_gross_emis_commod_soil_only}*tif'))
+            tiles_to_delete.extend(glob.glob(f'*{cn.pattern_gross_emis_shifting_ag_soil_only}*tif'))
+            tiles_to_delete.extend(glob.glob(f'*{cn.pattern_gross_emis_forestry_soil_only}*tif'))
+            tiles_to_delete.extend(glob.glob(f'*{cn.pattern_gross_emis_wildfire_soil_only}*tif'))
+            tiles_to_delete.extend(glob.glob(f'*{cn.pattern_gross_emis_urban_soil_only}*tif'))
+            tiles_to_delete.extend(glob.glob(f'*{cn.pattern_gross_emis_no_driver_soil_only}*tif'))
+            tiles_to_delete.extend(glob.glob(f'*{cn.pattern_gross_emis_nodes_soil_only}*tif'))
             uu.print_log(f'  Deleting {len(tiles_to_delete)} tiles...')
 
             for tile_to_delete in tiles_to_delete:

--- a/run_full_model.py
+++ b/run_full_model.py
@@ -11,9 +11,6 @@ docker build . -t gfw/carbon-budget
 Enter Docker container:
 docker run --rm -it -e AWS_SECRET_ACCESS_KEY=[] -e AWS_ACCESS_KEY_ID=[] gfw/carbon-budget
 
-Compile C++ emissions module (for standard model and sensitivity analyses that using standard emissions model)
-c++ /usr/local/app/emissions/cpp_util/calc_gross_emissions_generic.cpp -o /usr/local/app/emissions/cpp_util/calc_gross_emissions_generic.exe -lgdal
-
 Run 00N_000E in standard model; save intermediate outputs; do upload outputs to s3; run all model stages;
 starting from the beginning; get carbon pools at time of loss
 python -m run_full_model -si -t std -s all -r -d 20229999 -l 00N_000E -ce loss -tcd 30 -ln "00N_000E test"
@@ -480,7 +477,7 @@ def main ():
         uu.print_log(f':::::Processing time for gross_emissions: {elapsed_time}', "\n", "\n")
 
 
-    # Creates gross emissions tiles for biomass+soil by driver, gas, and all emissions combined
+    # Creates gross emissions tiles for soil only by driver, gas, and all emissions combined
     if 'gross_emissions_soil_only' in actual_stages:
 
         if not cn.SAVE_INTERMEDIATES:


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Make sure you are requesting to pull a topic/feature/bugfix branch (right side). Don't request your master!
- [x] Make sure you are making a pull request against the develop branch (left side). Also you should start your branch off our develop.
- [x] Check the commit's or even all commits' message styles matches our requested structure.
- [x] Check your code additions will fail neither code linting checks nor unit test.

## Pull request type

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
1.  Compiling calc_gross_emissions_soil_only.cpp resulted in the same warnings that compiling calc_gross_emissions_generic.cpp used to generate.
2.  Dockerfile has a step to compile calc_gross_emissions_generic.cpp.
3. shiftag_flu and urb_flu defined in decision trees in calc_gross_emissions_soil_only.cpp and calc_gross_emissions_generic.cpp rather than in constants.h.
4. run_full_model.py didn't include calculating emissions from soil only, even though that's a regular part of running the full model each year. soil_only emissions had to be run separately after the rest of the full model run.
5. Node code outputs for soil_only emissions were float32.
6. mp_calculate_gross_emissions.py did not compile C++ emissions file.

## What is the new behavior?
1. Compiling calc_gross_emissions_soil_only.cpp doesn't generate any warnings anymore, using the same method as calc_gross_emissions_generic.cpp.
2. It turned out that even though it looked like Dockerfile was successfully compiling emissions C++, it wasn't creating it. Couldn't figure out what the problem was, so I deleted the compilation step from Dockerfile.
3.  shiftag_flu and urb_flu defined in constants.h now, and calc_gross_emissions_soil_only.cpp and calc_gross_emissions_generic.cpp draw their F_lu from constants.h, like all other constants. I should've done this when I was centralizing constants in constants.h but apparently overlooked these.
4. run_full_model.py now includes a separate step for calculating gross emissions from soil_only after calculating emissions from biomass+soil. I made the soil_only step right after biomass+soil because they use the same inputs, so this should mean that the emissions inputs don't have to be re-downloaded. After soil_only_emissions has been created, the emissions inputs are deleted. I haven't actually run this full scale on an r5d.24xlarge machine, so I don't know if this is somehow going to run out of storage. Note that since run_full_model.py now can only calculate biomass_soil and soil_only emissions, I've removed the --emitted-pools-to-use argument (since both variants will be run). However, mp_calculate_gross_emissions.py still has the --emitted-pools-to-use argument so that only biomass_soil or soil_only can be run (mostly for testing). 
5. Node code outputs for soil_only emissions are UInt16 now (just like for biomass_soil).
6. mp_calculate_gross_emissions.py compiles C++ emission file for whichever one is needed based on the command line argument.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Changed documentation in various places.
I tested all of this on 00N_000E locally but not at all on an ec2 instance (either test tile or full run). 
