### PR TITLE
Feature/peat update 2023

### DIFF
--- a/analyses/net_flux.py
+++ b/analyses/net_flux.py
@@ -12,7 +12,7 @@ sys.path.append('../')
 import constants_and_names as cn
 import universal_util as uu
 
-@profile
+# @profile
 def net_calc(tile_id, pattern):
     """
     Creates net GHG flux tile set

--- a/constants_and_names.py
+++ b/constants_and_names.py
@@ -245,9 +245,9 @@ Dargie_peat_name = 'Dargie_et_al_2017__SimplifiedPeatMap_50m_peat_only.tif'
 Miettinen_peat_zip = 'Miettinen_2016__IDN_MYS_peat__aka_peatland_drainage_proj.zip'
 Miettinen_peat_shp = 'Miettinen_2016__IDN_MYS_peat__aka_peatland_drainage_proj.shp'
 Miettinen_peat_tif = 'Miettinen_2016__IDN_MYS_peat__aka_peatland_drainage_proj.tif'
-Xu_peat_zip = 'Xu_et_al_north_of_40N__20230228.zip'
-Xu_peat_shp = 'Xu_et_al_north_of_40N__20230228.shp'
-Xu_peat_tif = 'Xu_et_al_north_of_40N__20230228.tif'
+Xu_peat_zip = 'Xu_et_al_north_of_40N_reproj__20230228.zip'
+Xu_peat_shp = 'Xu_et_al_north_of_40N_reproj__20230228.shp'
+Xu_peat_tif = 'Xu_et_al_north_of_40N_reproj__20230228.tif'
 
 # Peat mask
 pattern_peat_mask = 'peat_mask_processed'

--- a/constants_and_names.py
+++ b/constants_and_names.py
@@ -203,9 +203,10 @@ gain_spreadsheet_dir = os.path.join(s3_base_dir, 'removal_rate_tables/')
 pattern_loss = 'GFW2021'
 loss_dir = 's3://gfw2-data/forest_change/hansen_2021/'
 
-# Hansen removals tiles (2001-2012)
-pattern_gain = 'Hansen_GFC2015_gain'
-gain_dir = 's3://gfw2-data/forest_change/tree_cover_gain/gaindata_2012/'
+# Hansen removals tiles based on canopy height (2001-2020)
+pattern_gain_data_lake = ''
+pattern_gain_ec2 = 'tree_cover_gain_2000_2020'
+gain_dir = 's3://gfw-data-lake/umd_tree_cover_gain_from_height/v202206/raster/epsg-4326/10/40000/gain/geotiff/'
 
 # Tree cover density 2000 tiles
 pattern_tcd = 'Hansen_GFC2014_treecover2000'
@@ -255,9 +256,9 @@ Miettinen_peat_shp = 'Miettinen_2016__IDN_MYS_peat__aka_peatland_drainage_proj.s
 Miettinen_peat_tif = 'Miettinen_2016__IDN_MYS_peat__aka_peatland_drainage_proj.tif'
 # Xu et al. 2018 for >40N (and <60S, though there's no land down there)
 # https://www.sciencedirect.com/science/article/abs/pii/S0341816217303004#ec0005
-Xu_peat_zip = 'Xu_et_al_north_of_40N_reproj__20230228.zip'
-Xu_peat_shp = 'Xu_et_al_north_of_40N_reproj__20230228.shp'
-Xu_peat_tif = 'Xu_et_al_north_of_40N_reproj__20230228.tif'
+Xu_peat_zip = 'Xu_et_al_north_of_40N_reproj__20230302.zip'
+Xu_peat_shp = 'Xu_et_al_north_of_40N_reproj__20230302.shp'
+Xu_peat_tif = 'Xu_et_al_north_of_40N_reproj__20230302.tif'
 
 # Peat mask
 pattern_peat_mask = 'peat_mask_processed'

--- a/constants_and_names.py
+++ b/constants_and_names.py
@@ -239,15 +239,19 @@ planted_forest_type_unmasked_dir = os.path.join(s3_base_dir, 'other_emissions_in
 
 # Peat mask inputs
 peat_unprocessed_dir = os.path.join(s3_base_dir, 'other_emissions_inputs/peatlands/raw/')
-cifor_peat_file = 'cifor_peat_mask.tif'
-jukka_peat_zip = 'Jukka_peatland.zip'
-jukka_peat_shp = 'peatland_drainage_proj.shp'
-soilgrids250_peat_url = 'https://files.isric.org/soilgrids/latest/data/wrb/MostProbable/'   #Value 14 is histosol according to https://files.isric.org/soilgrids/latest/data/wrb/MostProbable.qml
-pattern_soilgrids_most_likely_class = 'geotiff'
+Gumbricht_peat_name = 'Gumbricht_2017_CIFOR__TROP_SUBTROP_PeatV21_2016.tif'
+Dargie_name = 'Dargie_et_al_2017__SimplifiedPeatMap_50m.tif'
+Dargie_peat_name = 'Dargie_et_al_2017__SimplifiedPeatMap_50m_peat_only.tif'
+Miettinen_peat_zip = 'Miettinen_2016__IDN_MYS_peat__aka_peatland_drainage_proj.zip'
+Miettinen_peat_shp = 'Miettinen_2016__IDN_MYS_peat__aka_peatland_drainage_proj.shp'
+Miettinen_peat_tif = 'Miettinen_2016__IDN_MYS_peat__aka_peatland_drainage_proj.tif'
+Xu_peat_zip = 'Xu_et_al_north_of_40N__20230228.zip'
+Xu_peat_shp = 'Xu_et_al_north_of_40N__20230228.shp'
+Xu_peat_tif = 'Xu_et_al_north_of_40N__20230228.tif'
 
 # Peat mask
 pattern_peat_mask = 'peat_mask_processed'
-peat_mask_dir = os.path.join(s3_base_dir, 'other_emissions_inputs/peatlands/processed/20200807/')
+peat_mask_dir = os.path.join(s3_base_dir, 'other_emissions_inputs/peatlands/processed/20230301/')
 
 # Climate zone
 climate_zone_raw_dir = os.path.join(s3_base_dir, 'other_emissions_inputs/climate_zone/raw/')

--- a/constants_and_names.py
+++ b/constants_and_names.py
@@ -239,19 +239,29 @@ planted_forest_type_unmasked_dir = os.path.join(s3_base_dir, 'other_emissions_in
 
 # Peat mask inputs
 peat_unprocessed_dir = os.path.join(s3_base_dir, 'other_emissions_inputs/peatlands/raw/')
+# Gumbricht et al. 2017 (CIFOR) used for 40N to 60S
+# https://data.cifor.org/dataset.xhtml?persistentId=doi:10.17528/CIFOR/DATA.00058
+# https://data.cifor.org/file.xhtml?fileId=1727&version=7.0
 Gumbricht_peat_name = 'Gumbricht_2017_CIFOR__TROP_SUBTROP_PeatV21_2016.tif'
+# Dargie et al. 2017 for the Congo basin
+# https://congopeat.net/maps/
+# Probability layers of the 5 landcover types (GIS files) as published: https://drive.google.com/file/d/1zsUyFeO9TqRs5oxys3Ld4Ikgk8OYgHgc/
 Dargie_name = 'Dargie_et_al_2017__SimplifiedPeatMap_50m.tif'
 Dargie_peat_name = 'Dargie_et_al_2017__SimplifiedPeatMap_50m_peat_only.tif'
+# Miettinen et al. 2016 for Indonesia and Malaysia
+# https://www.sciencedirect.com/science/article/pii/S2351989415300470
 Miettinen_peat_zip = 'Miettinen_2016__IDN_MYS_peat__aka_peatland_drainage_proj.zip'
 Miettinen_peat_shp = 'Miettinen_2016__IDN_MYS_peat__aka_peatland_drainage_proj.shp'
 Miettinen_peat_tif = 'Miettinen_2016__IDN_MYS_peat__aka_peatland_drainage_proj.tif'
+# Xu et al. 2018 for >40N (and <60S, though there's no land down there)
+# https://www.sciencedirect.com/science/article/abs/pii/S0341816217303004#ec0005
 Xu_peat_zip = 'Xu_et_al_north_of_40N_reproj__20230228.zip'
 Xu_peat_shp = 'Xu_et_al_north_of_40N_reproj__20230228.shp'
 Xu_peat_tif = 'Xu_et_al_north_of_40N_reproj__20230228.tif'
 
 # Peat mask
 pattern_peat_mask = 'peat_mask_processed'
-peat_mask_dir = os.path.join(s3_base_dir, 'other_emissions_inputs/peatlands/processed/20230301/')
+peat_mask_dir = os.path.join(s3_base_dir, 'other_emissions_inputs/peatlands/processed/20230302/')
 
 # Climate zone
 climate_zone_raw_dir = os.path.join(s3_base_dir, 'other_emissions_inputs/climate_zone/raw/')

--- a/data_prep/model_extent.py
+++ b/data_prep/model_extent.py
@@ -9,7 +9,6 @@ import rasterio
 import sys
 from memory_profiler import profile
 
-sys.path.append('../')
 import constants_and_names as cn
 import universal_util as uu
 

--- a/data_prep/model_extent.py
+++ b/data_prep/model_extent.py
@@ -14,7 +14,7 @@ import constants_and_names as cn
 import universal_util as uu
 
 # @uu.counter
-@profile
+# @profile
 def model_extent(tile_id, pattern):
     """
     :param tile_id: tile to be processed, identified by its tile id

--- a/data_prep/mp_model_extent.py
+++ b/data_prep/mp_model_extent.py
@@ -49,7 +49,7 @@ def mp_model_extent(tile_id_list):
     # Files to download for this script.
     download_dict = {
                     cn.mangrove_biomass_2000_dir: [cn.pattern_mangrove_biomass_2000],
-                    cn.gain_dir: [cn.pattern_gain],
+                    cn.gain_dir: [cn.pattern_gain_data_lake],
                     cn.plant_pre_2000_processed_dir: [cn.pattern_plant_pre_2000]
     }
 

--- a/data_prep/mp_model_extent.py
+++ b/data_prep/mp_model_extent.py
@@ -110,6 +110,7 @@ def mp_model_extent(tile_id_list):
             pool.close()
             pool.join()
 
+
     # No single-processor versions of these check-if-empty functions
     output_pattern = output_pattern_list[0]
     if cn.count <= 2:  # For local tests
@@ -121,7 +122,7 @@ def mp_model_extent(tile_id_list):
             pool.join()
     else:
         processes = 58  # 50 processors = 620 GB peak; 55 = 640 GB; 58 = 650 GB (continues to increase very slowly several hundred tiles in)
-        uu.print_log(f'Checking for empty tiles of {output_pattern} pattern with {output_pattern} processors using light function...')
+        uu.print_log(f'Checking for empty tiles of {output_pattern} pattern with {output_pattern} processors...')
         with multiprocessing.Pool(processes) as pool:
             pool.map(partial(uu.check_and_delete_if_empty, output_pattern=output_pattern), tile_id_list)
             pool.close()

--- a/data_prep/mp_peatland_processing.py
+++ b/data_prep/mp_peatland_processing.py
@@ -63,20 +63,20 @@ def mp_peatland_processing(tile_id_list):
     cmd = ['unzip', '-o', '-j', cn.Xu_peat_zip]
     uu.log_subprocess_output_full(cmd)
 
-    # # Converts the Miettinen IDN/MYS peat shapefile to a raster
-    # uu.print_log('Rasterizing Miettinen peat...')
-    # cmd= ['gdal_rasterize', '-burn', '1', '-co', 'COMPRESS=DEFLATE', '-tr', '{}'.format(cn.Hansen_res), '{}'.format(cn.Hansen_res),
-    #       '-tap', '-ot', 'Byte', '-a_nodata', '0', cn.Miettinen_peat_shp, cn.Miettinen_peat_tif]
-    # uu.log_subprocess_output_full(cmd)
-    # uu.print_log('   Miettinen IDN/MYS peat rasterized')
+    # Converts the Miettinen IDN/MYS peat shapefile to a raster
+    uu.print_log('Rasterizing Miettinen map...')
+    cmd= ['gdal_rasterize', '-burn', '1', '-co', 'COMPRESS=DEFLATE', '-tr', '{}'.format(cn.Hansen_res), '{}'.format(cn.Hansen_res),
+          '-tap', '-ot', 'Byte', '-a_nodata', '0', cn.Miettinen_peat_shp, cn.Miettinen_peat_tif]
+    uu.log_subprocess_output_full(cmd)
+    uu.print_log('   Miettinen IDN/MYS peat rasterized')
 
-    # # Masks the Dargie raster to just the peat class (code 4).
-    # uu.print_log('Masking Dargie map to just peat class...')
-    # Dargie_calc = f'--calc=(A==4)'
-    # Dargie_outfilearg = f'--outfile={cn.Dargie_peat_name}'
-    # cmd = ['gdal_calc.py', '-A', cn.Dargie_name, Dargie_calc, Dargie_outfilearg,
-    #        '--NoDataValue=0', '--overwrite', '--co', 'COMPRESS=DEFLATE', '--type', 'Byte']
-    # uu.log_subprocess_output_full(cmd)
+    # Masks the Dargie raster to just the peat class (code 4).
+    uu.print_log('Masking Dargie map to just peat class...')
+    Dargie_calc = f'--calc=(A==4)'
+    Dargie_outfilearg = f'--outfile={cn.Dargie_peat_name}'
+    cmd = ['gdal_calc.py', '-A', cn.Dargie_name, Dargie_calc, Dargie_outfilearg,
+           '--NoDataValue=0', '--overwrite', '--co', 'COMPRESS=DEFLATE', '--type', 'Byte']
+    uu.log_subprocess_output_full(cmd)
 
     if cn.SINGLE_PROCESSOR:
         for tile_id in tile_id_list:

--- a/data_prep/mp_peatland_processing.py
+++ b/data_prep/mp_peatland_processing.py
@@ -1,24 +1,27 @@
 '''
 This script makes mask tiles of where peat pixels are. Peat is represented by 1s; non-peat is no-data.
-Between 40N and 60S, CIFOR peat and Jukka peat (IDN and MYS) are combined to map peat.
-Outside that band (>40N, since there are no tiles at >60S), SoilGrids250m is used to mask peat.
-Any pixel that is marked as most likely being a histosol subgroup is classified as peat.
-Between 40N and 60S, SoilGrids250m is not used.
+Between 40N and 60S, Gumbricht et al. 2017 (CIFOR) peat is used.
+Miettinen et al. 2016 and Dargie et al. 2017 supplement it in IDN/MYS and the Congo basin, respectively.
+Outside that band (>40N, since there are no tiles at >60S), Xu et al. 2018 is used to mask peat.
+Between 40N and 60S, Xu et al. 2018 is not used.
+
+python -m data_prep.mp_peatland_processing -l 00N_000E -nu
+python -m data_prep.mp_peatland_processing -l all
 '''
 
 
-import multiprocessing
 import argparse
 from functools import partial
-import datetime
-import sys
+import multiprocessing
 import os
-from subprocess import Popen, PIPE, STDOUT, check_call
+import sys
+
 import constants_and_names as cn
 import universal_util as uu
 from . import peatland_processing
 
-def mp_peatland_processing(tile_id_list, run_date = None):
+
+def mp_peatland_processing(tile_id_list):
 
     os.chdir(cn.docker_base_dir)
 
@@ -39,61 +42,75 @@ def mp_peatland_processing(tile_id_list, run_date = None):
     # A date can optionally be provided by the full model script or a run of this script.
     # This replaces the date in constants_and_names.
     # Only done if output upload is enabled.
-    if run_date is not None and no_upload is not None:
-        output_dir_list = uu.replace_output_dir_date(output_dir_list, run_date)
+    if cn.RUN_DATE is not None and cn.NO_UPLOAD is False:
+        output_dir_list = uu.replace_output_dir_date(output_dir_list, cn.RUN_DATE)
 
-
-    # Download SoilGrids250 most probable soil class rasters.
-    # There are 459 tiles and it takes about 20 minutes to download them
-    cmd = ['wget', '--recursive', '--no-parent', '-nH', '--cut-dirs=7',
-                   '--accept', '*.geotiff', '{}'.format(cn.soilgrids250_peat_url)]
-    uu.log_subprocess_output_full(cmd)
-
-    uu.print_log("Making SoilGrids250 most likely soil class vrt...")
-    check_call('gdalbuildvrt most_likely_soil_class.vrt *{}*'.format(cn.pattern_soilgrids_most_likely_class), shell=True)
-    uu.print_log("Done making SoilGrids250 most likely soil class vrt")
+    # NOTE: Locally merged in ArcMap all the Xu et al. 2018 peat shapefiles that are above 40N into a single shapefile:
+    # Xu_et_al_north_of_40N__20230228.shp. Only merged the Xu et al. shapefiles that were north of 40N because
+    # below that latitude, the model uses Gumbricht (CIFOR) 2017.
 
     # Downloads peat layers
-    uu.s3_file_download(os.path.join(cn.peat_unprocessed_dir, cn.cifor_peat_file), cn.docker_base_dir, sensit_type)
-    uu.s3_file_download(os.path.join(cn.peat_unprocessed_dir, cn.jukka_peat_zip), cn.docker_base_dir, sensit_type)
+    uu.s3_file_download(os.path.join(cn.peat_unprocessed_dir, cn.Gumbricht_peat_name), cn.docker_base_dir, cn.SENSIT_TYPE)
+    uu.s3_file_download(os.path.join(cn.peat_unprocessed_dir, cn.Miettinen_peat_zip), cn.docker_base_dir, cn.SENSIT_TYPE)
+    uu.s3_file_download(os.path.join(cn.peat_unprocessed_dir, cn.Xu_peat_zip), cn.docker_base_dir, cn.SENSIT_TYPE)
+    uu.s3_file_download(os.path.join(cn.peat_unprocessed_dir, cn.Dargie_name), cn.docker_base_dir, cn.SENSIT_TYPE)
 
-    # Unzips the Jukka peat shapefile (IDN and MYS)
-    cmd = ['unzip', '-o', '-j', cn.jukka_peat_zip]
+    # Unzips the Miettinen et al. peat shapefile (IDN and MYS)
+    cmd = ['unzip', '-o', '-j', cn.Miettinen_peat_zip]
     uu.log_subprocess_output_full(cmd)
 
-    jukka_tif = 'jukka_peat.tif'
-
-    # Converts the Jukka peat shapefile to a raster
-    uu.print_log('Rasterizing jukka peat...')
-    cmd= ['gdal_rasterize', '-burn', '1', '-co', 'COMPRESS=DEFLATE', '-tr', '{}'.format(cn.Hansen_res), '{}'.format(cn.Hansen_res),
-          '-tap', '-ot', 'Byte', '-a_nodata', '0', cn.jukka_peat_shp, jukka_tif]
+    # Unzips the Dargie et al. peat shapefile (Congo basin)
+    cmd = ['unzip', '-o', '-j', cn.Xu_peat_zip]
     uu.log_subprocess_output_full(cmd)
-    uu.print_log('   Jukka peat rasterized')
 
-    # For multiprocessor use
-    # count-10 maxes out at about 100 GB on an r5d.16xlarge
-    processes=cn.count-5
-    uu.print_log('Peatland preprocessing max processors=', processes)
-    pool = multiprocessing.Pool(processes)
-    pool.map(peatland_processing.create_peat_mask_tiles, tile_id_list)
-    pool.close()
-    pool.join()
+    # # Converts the Miettinen IDN/MYS peat shapefile to a raster
+    # uu.print_log('Rasterizing Miettinen peat...')
+    # cmd= ['gdal_rasterize', '-burn', '1', '-co', 'COMPRESS=DEFLATE', '-tr', '{}'.format(cn.Hansen_res), '{}'.format(cn.Hansen_res),
+    #       '-tap', '-ot', 'Byte', '-a_nodata', '0', cn.Miettinen_peat_shp, cn.Miettinen_peat_tif]
+    # uu.log_subprocess_output_full(cmd)
+    # uu.print_log('   Miettinen IDN/MYS peat rasterized')
 
-    # # For single processor use, for testing purposes
-    # for tile_id in tile_id_list:
-    #
-    #     peatland_processing.create_peat_mask_tiles(tile_id)
+    # # Masks the Dargie raster to just the peat class (code 4).
+    # uu.print_log('Masking Dargie map to just peat class...')
+    # Dargie_calc = f'--calc=(A==4)'
+    # Dargie_outfilearg = f'--outfile={cn.Dargie_peat_name}'
+    # cmd = ['gdal_calc.py', '-A', cn.Dargie_name, Dargie_calc, Dargie_outfilearg,
+    #        '--NoDataValue=0', '--overwrite', '--co', 'COMPRESS=DEFLATE', '--type', 'Byte']
+    # uu.log_subprocess_output_full(cmd)
 
+    if cn.SINGLE_PROCESSOR:
+        for tile_id in tile_id_list:
+            peatland_processing.create_peat_mask_tiles(tile_id)
+    else:
+        processes = 30 #30=XXX GB peak
+        uu.print_log('Peat map processors=', processes)
+        with multiprocessing.Pool(processes) as pool:
+            pool.map(peatland_processing.create_peat_mask_tiles, tile_id_list)
+            pool.close()
+            pool.join()
+
+
+    # No single-processor versions of these check-if-empty functions
     output_pattern = output_pattern_list[0]
-    processes = 50  # 50 processors = XXX GB peak
-    uu.print_log("Checking for empty tiles of {0} pattern with {1} processors...".format(output_pattern, processes))
-    pool = multiprocessing.Pool(processes)
-    pool.map(partial(uu.check_and_delete_if_empty, output_pattern=output_pattern), tile_id_list)
-    pool.close()
-    pool.join()
+    if cn.count <= 2:  # For local tests
+        processes = 1
+        uu.print_log(f'Checking for empty tiles of {output_pattern} pattern with {output_pattern} processors using light function...')
+        with multiprocessing.Pool(processes) as pool:
+            pool.map(partial(uu.check_and_delete_if_empty_light, output_pattern=output_pattern), tile_id_list)
+            pool.close()
+            pool.join()
+    else:
+        processes = 58  # 50 processors = XXX GB peak
+        uu.print_log(f'Checking for empty tiles of {output_pattern} pattern with {output_pattern} processors...')
+        with multiprocessing.Pool(processes) as pool:
+            pool.map(partial(uu.check_and_delete_if_empty, output_pattern=output_pattern), tile_id_list)
+            pool.close()
+            pool.join()
 
-    uu.print_log("Uploading output files")
-    uu.upload_final_set(output_dir_list[0], output_pattern_list[0])
+
+    # If no_upload flag is not activated (by choice or by lack of AWS credentials), output is uploaded
+    if not cn.NO_UPLOAD:
+        uu.upload_final_set(output_dir_list[0], output_pattern_list[0])
 
 
 if __name__ == '__main__':
@@ -104,16 +121,29 @@ if __name__ == '__main__':
                         help='List of tile ids to use in the model. Should be of form 00N_110E or 00N_110E,00N_120E or all.')
     parser.add_argument('--run-date', '-d', required=False,
                         help='Date of run. Must be format YYYYMMDD.')
+    parser.add_argument('--no-upload', '-nu', action='store_true',
+                       help='Disables uploading of outputs to s3')
+    parser.add_argument('--single-processor', '-sp', action='store_true',
+                       help='Uses single processing rather than multiprocessing')
     args = parser.parse_args()
-    tile_id_list = args.tile_id_list
-    run_date = args.run_date
 
-    sensit_type='std'
+    # Sets global variables to the command line arguments
+    cn.SENSIT_TYPE = 'std'
+    cn.RUN_DATE = args.run_date
+    cn.NO_UPLOAD = args.no_upload
+    cn.SINGLE_PROCESSOR = args.single_processor
+
+    tile_id_list = args.tile_id_list
+
+    # Disables upload to s3 if no AWS credentials are found in environment
+    if not uu.check_aws_creds():
+        cn.NO_UPLOAD = True
 
     # Create the output log
     uu.initiate_log(tile_id_list)
 
-    # Checks whether the tile_id_list argument is valid
+    # Checks whether the sensitivity analysis and tile_id_list arguments are valid
+    uu.check_sensit_type(cn.SENSIT_TYPE)
     tile_id_list = uu.tile_id_list_check(tile_id_list)
 
-    mp_peatland_processing(tile_id_list=tile_id_list, run_date=run_date)
+    mp_peatland_processing(tile_id_list=tile_id_list)

--- a/data_prep/mp_peatland_processing.py
+++ b/data_prep/mp_peatland_processing.py
@@ -82,7 +82,7 @@ def mp_peatland_processing(tile_id_list):
         for tile_id in tile_id_list:
             peatland_processing.create_peat_mask_tiles(tile_id)
     else:
-        processes = 30 #30=XXX GB peak
+        processes = 60 #30=160 GB peak; 60=XXX GB peak
         uu.print_log('Peat map processors=', processes)
         with multiprocessing.Pool(processes) as pool:
             pool.map(peatland_processing.create_peat_mask_tiles, tile_id_list)
@@ -100,7 +100,7 @@ def mp_peatland_processing(tile_id_list):
             pool.close()
             pool.join()
     else:
-        processes = 58  # 50 processors = XXX GB peak
+        processes = 75  # 58 processors = 220 GB peak; 75=XXX GB peak
         uu.print_log(f'Checking for empty tiles of {output_pattern} pattern with {output_pattern} processors...')
         with multiprocessing.Pool(processes) as pool:
             pool.map(partial(uu.check_and_delete_if_empty, output_pattern=output_pattern), tile_id_list)

--- a/data_prep/mp_peatland_processing.py
+++ b/data_prep/mp_peatland_processing.py
@@ -82,7 +82,7 @@ def mp_peatland_processing(tile_id_list):
         for tile_id in tile_id_list:
             peatland_processing.create_peat_mask_tiles(tile_id)
     else:
-        processes = 60 #30=160 GB peak; 60=XXX GB peak
+        processes = 60 #30=160 GB peak; 60=280 GB peak
         uu.print_log('Peat map processors=', processes)
         with multiprocessing.Pool(processes) as pool:
             pool.map(peatland_processing.create_peat_mask_tiles, tile_id_list)
@@ -100,7 +100,7 @@ def mp_peatland_processing(tile_id_list):
             pool.close()
             pool.join()
     else:
-        processes = 75  # 58 processors = 220 GB peak; 75=XXX GB peak
+        processes = 75  # 58 processors = 220 GB peak; 75=??? GB peak
         uu.print_log(f'Checking for empty tiles of {output_pattern} pattern with {output_pattern} processors...')
         with multiprocessing.Pool(processes) as pool:
             pool.map(partial(uu.check_and_delete_if_empty, output_pattern=output_pattern), tile_id_list)

--- a/data_prep/peatland_processing.py
+++ b/data_prep/peatland_processing.py
@@ -63,8 +63,6 @@ def create_peat_mask_tiles(tile_id):
         uu.print_log(f'{tile_id} created.')
 
 
-    os.quit()
-
     # All of the below is to add metadata tags to the output peat masks.
     # For some reason, just doing what's at https://rasterio.readthedocs.io/en/latest/topics/tags.html
     # results in the data getting removed.

--- a/data_prep/peatland_processing.py
+++ b/data_prep/peatland_processing.py
@@ -62,16 +62,15 @@ def create_peat_mask_tiles(tile_id):
         uu.log_subprocess_output_full(cmd)
         uu.print_log(f'{tile_id} created.')
 
+
+    os.quit()
+
     # All of the below is to add metadata tags to the output peat masks.
     # For some reason, just doing what's at https://rasterio.readthedocs.io/en/latest/topics/tags.html
     # results in the data getting removed.
     # I found it necessary to copy the peat mask and read its windows into a new copy of the file, to which the
     # metadata tags are added. I'm sure there's an easier way to do this but I couldn't figure out how.
     # I know it's very convoluted but I really couldn't figure out how to add the tags without erasing the data.
-    # To make it even stranger, adding the tags before the gdal processing seemed to work fine for the non-tropical
-    # (SoilGrids) tiles but not for the tropical (Gumbricht/Miettinen) tiles (i.e. data didn't disappear in the non-tropical
-    # tiles if I added the tags before the GDAL steps but the tropical data did disappear).
-
     copyfile(out_tile_no_tag, out_tile)
 
     uu.print_log("Adding metadata tags to", tile_id)
@@ -100,7 +99,7 @@ def create_peat_mask_tiles(tile_id):
         out_tile_tagged.update_tags(
             key='1 = peat. 0 = not peat.')
         out_tile_tagged.update_tags(
-            source='Gumbricht et al. 2017 for <40N>; Miettinen et al. and Dargie et al. where they occur; Xu et al. for >40N')
+            source='Gumbricht et al. 2017 for <40N; Miettinen et al. and Dargie et al. where they occur; Xu et al. 2018 for >=40N')
         out_tile_tagged.update_tags(
             extent='Full extent of input datasets')
 
@@ -117,7 +116,3 @@ def create_peat_mask_tiles(tile_id):
 
     # Prints information about the tile that was just processed
     uu.end_of_fx_summary(start, tile_id, cn.pattern_peat_mask)
-
-
-
-

--- a/data_prep/peatland_processing.py
+++ b/data_prep/peatland_processing.py
@@ -1,8 +1,9 @@
 '''
 This script makes mask tiles of where peat pixels are. Peat is represented by 1s; non-peat is no-data.
-Between 40N and 60S, CIFOR peat and Jukka peat (IDN and MYS) are combined to map peat.
-Outside that band (>40N, since there are no tiles at >60S), SoilGrids250m is used to mask peat.
-Any pixel that is marked as most likely being a histosol subgroup is classified as peat.
+Between 40N and 60S, Gumbricht et al. 2017 (CIFOR) peat is used.
+Miettinen et al. 2016 and Dargie et al. 2017 supplement it in IDN/MYS and the Congo basin, respectively.
+Outside that band (>40N, since there are no tiles at >60S), Xu et al. 2018 is used to mask peat.
+Between 40N and 60S, Xu et al. 2018 is not used.
 '''
 
 from subprocess import Popen, PIPE, STDOUT, check_call
@@ -11,11 +12,16 @@ import rasterio
 from shutil import copyfile
 import datetime
 import sys
-sys.path.append('../')
+
 import constants_and_names as cn
 import universal_util as uu
 
+
 def create_peat_mask_tiles(tile_id):
+    """
+    :param tile_id: tile to be processed, identified by its tile id
+    :return: Peat mask: 1 is peat, 0 is no peat
+    """
 
     # Start time
     start = datetime.datetime.now()
@@ -24,45 +30,37 @@ def create_peat_mask_tiles(tile_id):
     xmin, ymin, xmax, ymax = uu.coords(tile_id)
     uu.print_log("  ymax:", ymax, "; ymin:", ymin, "; xmax", xmax, "; xmin:", xmin)
 
-    out_tile_no_tag = '{0}_{1}_no_tag.tif'.format(tile_id, cn.pattern_peat_mask)
-    out_tile = '{0}_{1}.tif'.format(tile_id, cn.pattern_peat_mask)
+    out_tile_no_tag = f'{tile_id}_{cn.pattern_peat_mask}_no_tag.tif'
+    out_tile = f'{tile_id}_{cn.pattern_peat_mask}.tif'
 
-    # If the tile is outside the band covered by the CIFOR peat raster, SoilGrids250m is used
+    # If the tile is outside the band covered by the Gumbricht 2017/CIFOR peat raster, Xu et al. 2018 is used.
     if ymax > 40 or ymax < -60:
 
-        uu.print_log("{} is outside CIFOR band. Using SoilGrids250m organic soil mask...".format(tile_id))
+        uu.print_log(f'{tile_id} is outside Gumbricht band. Using Xu et al. 2018 peat map...')
 
-        out_intermediate = '{0}_intermediate.tif'.format(tile_id, cn.pattern_peat_mask)
-
-        # Cuts the SoilGrids250m global raster to the focal tile
-        uu.warp_to_Hansen('most_likely_soil_class.vrt', out_intermediate, xmin, ymin, xmax, ymax, 'Byte')
-
-        # Removes all non-histosol sub-groups from the SoilGrids raster.
-        # Ideally, this would be done once on the entire SoilGrids raster in the main function but I didn't think of that.
-        # Code 14 is the histosol subgroup in SoilGrids250 (https://files.isric.org/soilgrids/latest/data/wrb/MostProbable.qml).
-        calc = '--calc=(A==14)'
-        peat_mask_out_filearg = '--outfile={}'.format(out_tile_no_tag)
-        cmd = ['gdal_calc.py', '-A', out_intermediate, calc, peat_mask_out_filearg,
-               '--NoDataValue=0', '--overwrite', '--co', 'COMPRESS=DEFLATE', '--type=Byte', '--quiet']
+        # Converts the Xu >40N peat shapefile to a raster
+        cmd = ['gdal_rasterize', '-burn', '1', '-co', 'COMPRESS=DEFLATE', '-tr', str(cn.Hansen_res), str(cn.Hansen_res),
+               '-te', str(xmin), str(ymin), str(xmax), str(ymax),
+               '-tap', '-ot', 'Byte', '-a_nodata', '0', cn.Xu_peat_shp, out_tile_no_tag]
         uu.log_subprocess_output_full(cmd)
+        uu.print_log(f'{tile_id} created.')
 
-        uu.print_log("{} created.".format(tile_id))
-
-    # If the tile is inside the band covered by CIFOR, CIFOR is used (and Jukka in the tiles where it occurs).
-    # For some reason, the CIFOR raster has a color scheme that makes it symbolized from 0 to 255. This carries
+    # If the tile is inside the band covered by Gumbricht 2017/CIFOR, Gumbricht is used.
+    # Miettinen is added in IDN and MYS and Dargie is added in the Congo basin.
+    # For some reason, the Gumbricht raster has a color scheme that makes it symbolized from 0 to 255. This carries
     # over to the output file but that seems like a problem with the output symbology, not the values.
     # gdalinfo shows that the min and max values are 1, as they should be, and it visualizes correctly in ArcMap.
     else:
 
-        uu.print_log("{} is inside CIFOR band. Using CIFOR/Jukka combination...".format(tile_id))
+        uu.print_log(f"{tile_id} is inside Gumbricht band. Using Gumbricht/Miettinen/Dargie combination...")
 
-        # Combines CIFOR and Jukka (if it occurs there)
-        cmd = ['gdalwarp', '-t_srs', 'EPSG:4326', '-co', 'COMPRESS=DEFLATE', '-tr', '{}'.format(cn.Hansen_res), '{}'.format(cn.Hansen_res),
+        # Combines Gumbricht/CIFOR with Miettinen and Dargie (where they occur)
+        cmd = ['gdalwarp', '-t_srs', 'EPSG:4326', '-co', 'COMPRESS=DEFLATE', '-tr', str(cn.Hansen_res), str(cn.Hansen_res),
                '-tap', '-te', str(xmin), str(ymin), str(xmax), str(ymax),
-               '-dstnodata', '0', '-overwrite', '{}'.format(cn.cifor_peat_file), 'jukka_peat.tif', out_tile_no_tag]
+               '-dstnodata', '0', '-overwrite',
+               cn.Gumbricht_peat_name, cn.Miettinen_peat_tif, cn.Dargie_peat_name, out_tile_no_tag]
         uu.log_subprocess_output_full(cmd)
-
-        uu.print_log("{} created.".format(tile_id))
+        uu.print_log(f'{tile_id} created.')
 
     # All of the below is to add metadata tags to the output peat masks.
     # For some reason, just doing what's at https://rasterio.readthedocs.io/en/latest/topics/tags.html
@@ -71,7 +69,7 @@ def create_peat_mask_tiles(tile_id):
     # metadata tags are added. I'm sure there's an easier way to do this but I couldn't figure out how.
     # I know it's very convoluted but I really couldn't figure out how to add the tags without erasing the data.
     # To make it even stranger, adding the tags before the gdal processing seemed to work fine for the non-tropical
-    # (SoilGrids) tiles but not for the tropical (CIFOR/Jukka) tiles (i.e. data didn't disappear in the non-tropical
+    # (SoilGrids) tiles but not for the tropical (Gumbricht/Miettinen) tiles (i.e. data didn't disappear in the non-tropical
     # tiles if I added the tags before the GDAL steps but the tropical data did disappear).
 
     copyfile(out_tile_no_tag, out_tile)
@@ -102,7 +100,7 @@ def create_peat_mask_tiles(tile_id):
         out_tile_tagged.update_tags(
             key='1 = peat. 0 = not peat.')
         out_tile_tagged.update_tags(
-            source='Jukka for IDN and MYS; CIFOR for rest of tropics; SoilGrids250 (May 2020) most likely histosol for outside tropics')
+            source='Gumbricht et al. 2017 for <40N>; Miettinen et al. and Dargie et al. where they occur; Xu et al. for >40N')
         out_tile_tagged.update_tags(
             extent='Full extent of input datasets')
 

--- a/ec2_launch_template_startup_instructions.TXT
+++ b/ec2_launch_template_startup_instructions.TXT
@@ -75,25 +75,17 @@ ln -s /usr/local/bin/docker-compose /usr/bin/docker-compose
 docker-compose --version
 
 #############################
-# Copy latest flux model repo to the home folder
+# Clone latest flux model repo to the home folder
+# clone command suggested by Logan Byers. It resolves the problem of not being able to pull the repo after it was cloned, which was conflicting with not being able to SSH into the machine more than ~1 minute after it was created.
+# This formulation of git clone makes ec2-user the cloner, rather than root. It's no longer necessary to change ownership (chown) of the repo because carbon-budget will already be owned by ec2-user, not root.
 #############################
 cd /home/ec2-user
-git clone https://github.com/wri/carbon-budget
-cd carbon-budget
-
-cd /home/ec2-user/carbon-budget/
+su ec2-user -c "git clone https://github.com/wri/carbon-budget"
 
 #######################################
 # Starts the docker service
 #######################################
 sudo service docker start
-
-######################################
-# Gives the user (ec2-user) various permissions, such as ability to git pull and enter the docker container.
-#Based on https://techoverflow.net/2019/05/07/how-to-fix-git-error-cannot-open-git-fetch_head-permission-denied/
-######################################
-cd /
-sudo chown -R ec2-user: .
 
 # Replaces htop config file with my preferred configuration
 mkdir -p /home/ec2-user/.config/htop/

--- a/universal_util.py
+++ b/universal_util.py
@@ -699,7 +699,7 @@ def s3_folder_download(source, dest, sensit_type, pattern = None):
 # Source=source file on s3
 # dest=where to download onto spot machine
 # sensit_type = whether the model is standard or a sensitivity analysis model run
-def s3_file_download(source, dest, sensit_type, pattern = none):
+def s3_file_download(source, dest, sensit_type, pattern = None):
 
     # Retrieves the s3 directory and name of the tile from the full path name
     dir = get_tile_dir(source)

--- a/universal_util.py
+++ b/universal_util.py
@@ -578,12 +578,14 @@ def s3_flexible_download(source_dir, pattern, dest, sensit_type, tile_id_list):
 
         # Creates a full download name (path and file)
         for tile_id in tile_id_list:
-            if pattern in [cn.pattern_gain, cn.pattern_tcd, cn.pattern_pixel_area, cn.pattern_loss]:   # For tiles that do not have the tile_id first
+            if pattern in [cn.pattern_tcd, cn.pattern_pixel_area, cn.pattern_loss]:   # For tiles that do not have the tile_id first
                 source = f'{source_dir}{pattern}_{tile_id}.tif'
+            elif pattern in [cn.pattern_gain_data_lake]:
+                source = f'{tile_id}.tif'
             else:  # For every other type of tile
                 source = f'{source_dir}{tile_id}_{pattern}.tif'
 
-            s3_file_download(source, dest, sensit_type)
+            s3_file_download(source, dest, pattern, sensit_type)
 
     # For downloading full sets of tiles
     else:
@@ -697,7 +699,7 @@ def s3_folder_download(source, dest, sensit_type, pattern = None):
 # Source=source file on s3
 # dest=where to download onto spot machine
 # sensit_type = whether the model is standard or a sensitivity analysis model run
-def s3_file_download(source, dest, sensit_type):
+def s3_file_download(source, dest, pattern, sensit_type):
 
     # Retrieves the s3 directory and name of the tile from the full path name
     dir = get_tile_dir(source)

--- a/universal_util.py
+++ b/universal_util.py
@@ -699,7 +699,7 @@ def s3_folder_download(source, dest, sensit_type, pattern = None):
 # Source=source file on s3
 # dest=where to download onto spot machine
 # sensit_type = whether the model is standard or a sensitivity analysis model run
-def s3_file_download(source, dest, pattern, sensit_type):
+def s3_file_download(source, dest, sensit_type, pattern = none):
 
     # Retrieves the s3 directory and name of the tile from the full path name
     dir = get_tile_dir(source)


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Make sure you are requesting to pull a topic/feature/bugfix branch (right side). Don't request your master!
- [x] Make sure you are making a pull request against the develop branch (left side). Also you should start your branch off our develop.
- [x] Check the commit's or even all commits' message styles matches our requested structure.
- [x] Check your code additions will fail neither code linting checks nor unit test.

## Pull request type

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
1. Global peat map tiles didn't use the latest data sources. Below 40N, peat was Gumbricht et al. 2017 (CIFOR), supplemented with Miettinen et al. 2016 in Indonesia and Malaysia. Above 40N, peat was SoilGrids250 pixels where histosols were most likely. 


## What is the new behavior?
1. Global peat map tiles use improved data sources. Below 40N, peat is still Gumbricht et al. 2017 (CIFOR), now supplemented with Miettinen et al. 2016 in Indonesia and Malaysia and Dargie et al. 2017 in the Congo basin. Above 40N, peat is now from Xu et al. 2018.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Peat data sources:

CIFOR 2017 (Gumbricht et al. 2017) for tropics: https://data.cifor.org/dataset.xhtml?persistentId=doi:10.17528/CIFOR/DATA.00058, https://data.cifor.org/file.xhtml?fileId=1727&version=7.0 specifically (currently using in model). An expert system model for mapping tropical wetlands and peatlands reveals South America as the largest contributor. Glob. Change Biol. 23, 3581–3599 (2017). https://onlinelibrary.wiley.com/doi/full/10.1111/gcb.13689

Dargie et al. 2017 for area it covers in central Africa: https://congopeat.net/maps/, [Probability layers of the 5 landcover types (GIS files) as published](https://drive.google.com/file/d/1zsUyFeO9TqRs5oxys3Ld4Ikgk8OYgHgc/)

Miettinen et al. 2016 for Indonesia and Malaysia: https://www.sciencedirect.com/science/article/pii/S2351989415300470

Xu et al. 2018 for outside the tropics: https://www.sciencedirect.com/science/article/abs/pii/S0341816217303004#ec0005

Other global peat maps were considered but not used. I couldn't find the UNEP 2022 global peat map for download; the report didn't have a GIS file download link and the report contact never responded to me. 

There's also a global peat map by [Melton et al. 2022](https://gmd.copernicus.org/articles/15/4709/2022/), which uses machine learning to map peat at 5 arcminutes (~10x10km at the equator). It's another option for a global map (probably in conjunction with Miettinen/WI for IDN/MYS), but I am not keen on the coarser resolution than Xu et al. Also, the global peat area in Melton using machine learning is 4.04 million km^2, whereas in Xu et al. using data aggregation it's 4.23 million km^2. I'd rather go with the larger, more conservative area for peat in general, and I prefer the data compilation approach of Xu et al. to the ML approach of Melton et al. in this case.
