### PR TITLE
Feature/tree cover gain 2000 2020

### DIFF
--- a/analyses/derivative_outputs.py
+++ b/analyses/derivative_outputs.py
@@ -46,7 +46,7 @@ def forest_extent_per_pixel_outputs(tile_id, input_pattern, output_patterns):
     focal_tile = f'{tile_id}_{input_pattern}.tif'
     pixel_area = f'{cn.pattern_pixel_area}_{tile_id}.tif'
     tcd = f'{cn.pattern_tcd}_{tile_id}.tif'
-    gain = f'{cn.pattern_gain}_{tile_id}.tif'
+    gain = f'{tile_id}_{cn.pattern_gain_ec2}.tif'
     mangrove = f'{tile_id}_{cn.pattern_mangrove_biomass_2000}.tif'
 
     # Names of outputs.

--- a/analyses/derivative_outputs.py
+++ b/analyses/derivative_outputs.py
@@ -65,7 +65,12 @@ def forest_extent_per_pixel_outputs(tile_id, input_pattern, output_patterns):
 
     pixel_area_src = rasterio.open(pixel_area)
     tcd_src = rasterio.open(tcd)
-    gain_src = rasterio.open(gain)
+
+    try:
+        gain_src = rasterio.open(gain)
+        uu.print_log(f'    Gain tile found for {tile_id}')
+    except:
+        uu.print_log(f'    No gain tile found for {tile_id}')
 
     try:
         mangrove_src = rasterio.open(mangrove)
@@ -130,7 +135,11 @@ def forest_extent_per_pixel_outputs(tile_id, input_pattern, output_patterns):
         in_window = in_src.read(1, window=window)
         pixel_area_window = pixel_area_src.read(1, window=window)
         tcd_window = tcd_src.read(1, window=window)
-        gain_window = gain_src.read(1, window=window)
+
+        try:
+            gain_window = gain_src.read(1, window=window)
+        except:
+            gain_window = np.zeros((window.height, window.width), dtype='uint8')
 
         try:
             mangrove_window = mangrove_src.read(1, window=window)

--- a/analyses/download_tile_set.py
+++ b/analyses/download_tile_set.py
@@ -22,7 +22,7 @@ def download_tile_set(sensit_type, tile_id_list):
 
     uu.print_log("Downloading all tiles for: ", tile_id_list)
 
-    wd = os.path.join(cn.docker_base_dir,"spot_download")
+    wd = os.path.join(cn.docker_tile_dir, "spot_download")
 
     os.chdir(wd)
 

--- a/analyses/download_tile_set.py
+++ b/analyses/download_tile_set.py
@@ -78,7 +78,7 @@ def download_tile_set(sensit_type, tile_id_list):
         pattern = values[0]
         uu.s3_flexible_download(dir, pattern, wd, sensit_type, tile_id_list)
 
-    cmd = ['aws', 's3', 'cp', cn.output_aggreg_dir, wd, '--recursive']
+    cmd = ['aws', 's3', 'sync', cn.output_aggreg_dir, wd]
     uu.log_subprocess_output_full(cmd)
 
     tile_list = glob.glob('*tif')

--- a/analyses/mp_derivative_outputs.py
+++ b/analyses/mp_derivative_outputs.py
@@ -102,7 +102,7 @@ def mp_derivative_outputs(tile_id_list_outer):
     uu.s3_flexible_download(cn.pixel_area_dir, cn.pattern_pixel_area, cn.docker_tile_dir, cn.SENSIT_TYPE, tile_id_list_outer)
     # Tree cover density, Hansen gain, and mangrove biomass tiles-- necessary for masking to forest extent
     uu.s3_flexible_download(cn.tcd_dir, cn.pattern_tcd, cn.docker_tile_dir, cn.SENSIT_TYPE, tile_id_list_outer)
-    uu.s3_flexible_download(cn.gain_dir, cn.pattern_gain, cn.docker_tile_dir, cn.SENSIT_TYPE, tile_id_list_outer)
+    uu.s3_flexible_download(cn.gain_dir, cn.pattern_gain_data_lake, cn.docker_tile_dir, cn.SENSIT_TYPE, tile_id_list_outer)
     uu.s3_flexible_download(cn.mangrove_biomass_2000_dir, cn.pattern_mangrove_biomass_2000, cn.docker_tile_dir, cn.SENSIT_TYPE, tile_id_list_outer)
 
     # Iterates through the types of tiles to be processed

--- a/analyses/mp_derivative_outputs.py
+++ b/analyses/mp_derivative_outputs.py
@@ -41,7 +41,7 @@ def mp_derivative_outputs(tile_id_list_outer):
     :return: derivative outputs at native and aggregated resolution for emissions, removals, and net flux
     """
 
-    os.chdir(cn.docker_base_dir)
+    os.chdir(cn.docker_tile_dir)
 
     # If a full model run is specified, the correct set of tiles for the particular script is listed
     if tile_id_list_outer == 'all':
@@ -99,11 +99,11 @@ def mp_derivative_outputs(tile_id_list_outer):
         output_dir_list = uu.replace_output_dir_date(output_dir_list, cn.RUN_DATE)
 
     # Pixel area tiles-- necessary for calculating per pixel values
-    uu.s3_flexible_download(cn.pixel_area_dir, cn.pattern_pixel_area, cn.docker_base_dir, cn.SENSIT_TYPE, tile_id_list_outer)
+    uu.s3_flexible_download(cn.pixel_area_dir, cn.pattern_pixel_area, cn.docker_tile_dir, cn.SENSIT_TYPE, tile_id_list_outer)
     # Tree cover density, Hansen gain, and mangrove biomass tiles-- necessary for masking to forest extent
-    uu.s3_flexible_download(cn.tcd_dir, cn.pattern_tcd, cn.docker_base_dir, cn.SENSIT_TYPE, tile_id_list_outer)
-    uu.s3_flexible_download(cn.gain_dir, cn.pattern_gain, cn.docker_base_dir, cn.SENSIT_TYPE, tile_id_list_outer)
-    uu.s3_flexible_download(cn.mangrove_biomass_2000_dir, cn.pattern_mangrove_biomass_2000, cn.docker_base_dir, cn.SENSIT_TYPE, tile_id_list_outer)
+    uu.s3_flexible_download(cn.tcd_dir, cn.pattern_tcd, cn.docker_tile_dir, cn.SENSIT_TYPE, tile_id_list_outer)
+    uu.s3_flexible_download(cn.gain_dir, cn.pattern_gain, cn.docker_tile_dir, cn.SENSIT_TYPE, tile_id_list_outer)
+    uu.s3_flexible_download(cn.mangrove_biomass_2000_dir, cn.pattern_mangrove_biomass_2000, cn.docker_tile_dir, cn.SENSIT_TYPE, tile_id_list_outer)
 
     # Iterates through the types of tiles to be processed
     for input_dir, download_pattern_name in download_dict.items():
@@ -125,7 +125,7 @@ def mp_derivative_outputs(tile_id_list_outer):
 
         # Downloads input files or entire directories, depending on how many tiles are in the tile_id_list
         uu.print_log(f'Downloading tiles from {input_dir}')
-        uu.s3_flexible_download(input_dir, input_pattern, cn.docker_base_dir, cn.SENSIT_TYPE, tile_id_list_inner)
+        uu.s3_flexible_download(input_dir, input_pattern, cn.docker_tile_dir, cn.SENSIT_TYPE, tile_id_list_inner)
 
         # Blank list of output patterns, populated below
         output_patterns = []

--- a/analyses/mp_net_flux.py
+++ b/analyses/mp_net_flux.py
@@ -23,7 +23,7 @@ def mp_net_flux(tile_id_list):
         Units: Mg CO2e/ha over the model period
     """
 
-    os.chdir(cn.docker_base_dir)
+    os.chdir(cn.docker_tile_dir)
 
     # If a full model run is specified, the correct set of tiles for the particular script is listed
     if tile_id_list == 'all':
@@ -52,7 +52,7 @@ def mp_net_flux(tile_id_list):
     for key, values in download_dict.items():
         directory = key
         pattern = values[0]
-        uu.s3_flexible_download(directory, pattern, cn.docker_base_dir, cn.SENSIT_TYPE, tile_id_list)
+        uu.s3_flexible_download(directory, pattern, cn.docker_tile_dir, cn.SENSIT_TYPE, tile_id_list)
 
 
     # If the model run isn't the standard one, the output directory and file names are changed

--- a/analyses/mp_tile_statistics.py
+++ b/analyses/mp_tile_statistics.py
@@ -16,7 +16,7 @@ import universal_util as uu
 
 def mp_tile_statistics(sensit_type, tile_id_list):
 
-    os.chdir(cn.docker_base_dir)
+    os.chdir(cn.docker_tile_dir)
 
     # The column names for the tile summary statistics.
     # If the statistics calculations are changed in tile_statistics.py, the list here needs to be changed, too.
@@ -34,7 +34,7 @@ def mp_tile_statistics(sensit_type, tile_id_list):
     uu.print_log(tile_id_list)
 
     # Pixel area tiles-- necessary for calculating sum of pixels for any set of tiles
-    uu.s3_flexible_download(cn.pixel_area_dir, cn.pattern_pixel_area, cn.docker_base_dir, 'std', tile_id_list)
+    uu.s3_flexible_download(cn.pixel_area_dir, cn.pattern_pixel_area, cn.docker_tile_dir, 'std', tile_id_list)
 
     # For downloading all tiles in selected folders
     download_dict = {
@@ -150,7 +150,7 @@ def mp_tile_statistics(sensit_type, tile_id_list):
         # Downloads input files or entire directories, depending on how many tiles are in the tile_id_list
         dir = key
         pattern = values[0]
-        uu.s3_flexible_download(dir, pattern, cn.docker_base_dir, sensit_type, tile_id_list)
+        uu.s3_flexible_download(dir, pattern, cn.docker_tile_dir, sensit_type, tile_id_list)
 
         # List of all the tiles on the spot machine to be summarized (excludes pixel area tiles and tiles created by gdal_calc
         # (in case this script was already run on this spot machine and created output from gdal_calc)

--- a/carbon_pools/create_carbon_pools.py
+++ b/carbon_pools/create_carbon_pools.py
@@ -355,7 +355,6 @@ def create_BGC(tile_id, mang_BGB_AGB_ratio, carbon_pool_extent):
             source='WHRC (if standard model) or JPL (if biomass_swap sensitivity analysis) and mangrove AGB (Simard et al. 2018). Gross removals added to AGC2000 to get AGC in loss year. AGC:BGC for mangrove and non-mangrove forests applied.')
         dst_BGC_emis_year.update_tags(
             extent='tree cover loss pixels within model extent')
-        print(BGC_emis_year)
 
     uu.print_log(f'  Reading input files for {tile_id}')
 

--- a/carbon_pools/create_carbon_pools.py
+++ b/carbon_pools/create_carbon_pools.py
@@ -3,12 +3,10 @@
 import datetime
 import os
 import rasterio
-import sys
 import numpy as np
 import pandas as pd
 from memory_profiler import profile
 
-sys.path.append('../')
 import constants_and_names as cn
 import universal_util as uu
 

--- a/carbon_pools/create_carbon_pools.py
+++ b/carbon_pools/create_carbon_pools.py
@@ -20,13 +20,13 @@ def prepare_gain_table():
 
     # Table with IPCC Wetland Supplement Table 4.4 default mangrove removals rates
     # cmd = ['aws', 's3', 'cp', os.path.join(cn.gain_spreadsheet_dir, cn.gain_spreadsheet), cn.docker_base_dir, '--no-sign-request']
-    cmd = ['aws', 's3', 'cp', os.path.join(cn.gain_spreadsheet_dir, cn.gain_spreadsheet), cn.docker_base_dir]
+    cmd = ['aws', 's3', 'cp', os.path.join(cn.gain_spreadsheet_dir, cn.gain_spreadsheet), cn.docker_tile_dir]
     uu.log_subprocess_output_full(cmd)
 
     pd.options.mode.chained_assignment = None
 
     # Imports the table with the ecozone-continent codes and the carbon removals rates
-    gain_table = pd.read_excel(f'{cn.docker_base_dir}{cn.gain_spreadsheet}',
+    gain_table = pd.read_excel(f'{cn.docker_tile_dir}{cn.gain_spreadsheet}',
                                sheet_name="mangrove gain, for model")
 
     # Removes rows with duplicate codes (N. and S. America for the same ecozone)

--- a/carbon_pools/create_carbon_pools.py
+++ b/carbon_pools/create_carbon_pools.py
@@ -85,7 +85,7 @@ def create_AGC(tile_id, carbon_pool_extent):
     # Names of the input tiles. Creates the names even if the files don't exist.
     removal_forest_type = uu.sensit_tile_rename(cn.SENSIT_TYPE, tile_id, cn.pattern_removal_forest_type)
     mangrove_biomass_2000 = uu.sensit_tile_rename(cn.SENSIT_TYPE, tile_id, cn.pattern_mangrove_biomass_2000)
-    gain = uu.sensit_tile_rename(cn.SENSIT_TYPE, cn.pattern_gain, tile_id)
+    gain = uu.sensit_tile_rename(cn.SENSIT_TYPE, cn.pattern_gain_ec2, tile_id)
     annual_gain_AGC = uu.sensit_tile_rename(cn.SENSIT_TYPE, tile_id, cn.pattern_annual_gain_AGC_all_types)
     cumul_gain_AGCO2 = uu.sensit_tile_rename(cn.SENSIT_TYPE, tile_id, cn.pattern_cumul_gain_AGCO2_all_types)
     natrl_forest_biomass_2000 = uu.sensit_tile_rename_biomass(cn.SENSIT_TYPE, tile_id)

--- a/carbon_pools/create_soil_C.py
+++ b/carbon_pools/create_soil_C.py
@@ -14,12 +14,10 @@ So, I switched to this somewhat more convoluted method that uses both gdal and r
 '''
 
 import datetime
-from subprocess import Popen, PIPE, STDOUT, check_call
 import numpy as np
 import rasterio
 import os
-import sys
-sys.path.append('../')
+
 import universal_util as uu
 import constants_and_names as cn
 

--- a/carbon_pools/mp_create_carbon_pools.py
+++ b/carbon_pools/mp_create_carbon_pools.py
@@ -42,7 +42,7 @@ def mp_create_carbon_pools(tile_id_list, carbon_pool_extent):
     :return: set of tiles with each carbon pool density (Mg/ha): aboveground, belowground, dead wood, litter, soil, total
     """
 
-    os.chdir(cn.docker_base_dir)
+    os.chdir(cn.docker_tile_dir)
 
     if (cn.SENSIT_TYPE != 'std') & (carbon_pool_extent != 'loss'):
         uu.exception_log("Sensitivity analysis run must use loss extent")
@@ -155,7 +155,7 @@ def mp_create_carbon_pools(tile_id_list, carbon_pool_extent):
     for key, values in download_dict.items():
         directory = key
         pattern = values[0]
-        uu.s3_flexible_download(directory, pattern, cn.docker_base_dir, cn.SENSIT_TYPE, tile_id_list)
+        uu.s3_flexible_download(directory, pattern, cn.docker_tile_dir, cn.SENSIT_TYPE, tile_id_list)
 
 
     # If the model run isn't the standard one, the output directory and file names are changed
@@ -428,7 +428,7 @@ def mp_create_carbon_pools(tile_id_list, carbon_pool_extent):
         for key, values in download_dict.items():
             directory = key
             pattern = values[0]
-            uu.s3_flexible_download(directory, pattern, cn.docker_base_dir, cn.SENSIT_TYPE, tile_id_list)
+            uu.s3_flexible_download(directory, pattern, cn.docker_tile_dir, cn.SENSIT_TYPE, tile_id_list)
 
 
     uu.print_log('Creating tiles of total carbon')

--- a/carbon_pools/mp_create_carbon_pools.py
+++ b/carbon_pools/mp_create_carbon_pools.py
@@ -92,7 +92,7 @@ def mp_create_carbon_pools(tile_id_list, carbon_pool_extent):
             cn.precip_processed_dir: [cn.pattern_precip],
             cn.elevation_processed_dir: [cn.pattern_elevation],
             cn.soil_C_full_extent_2000_dir: [cn.pattern_soil_C_full_extent_2000],
-            cn.gain_dir: [cn.pattern_gain],
+            cn.gain_dir: [cn.pattern_gain_data_lake],
             cn.BGB_AGB_ratio_dir: [cn.pattern_BGB_AGB_ratio]
         }
 
@@ -130,7 +130,7 @@ def mp_create_carbon_pools(tile_id_list, carbon_pool_extent):
             cn.precip_processed_dir: [cn.pattern_precip],
             cn.elevation_processed_dir: [cn.pattern_elevation],
             cn.soil_C_full_extent_2000_dir: [cn.pattern_soil_C_full_extent_2000],
-            cn.gain_dir: [cn.pattern_gain],
+            cn.gain_dir: [cn.pattern_gain_data_lake],
             cn.BGB_AGB_ratio_dir: [cn.pattern_BGB_AGB_ratio],
             cn.annual_gain_AGC_all_types_dir: [cn.pattern_annual_gain_AGC_all_types],
             cn.cumul_gain_AGCO2_all_types_dir: [cn.pattern_cumul_gain_AGCO2_all_types]
@@ -288,7 +288,7 @@ def mp_create_carbon_pools(tile_id_list, carbon_pool_extent):
         tiles_to_delete = []
         # tiles_to_delete.extend(glob.glob(f'*{cn.pattern_BGC_2000}*tif'))
         tiles_to_delete.extend(glob.glob(f'*{cn.pattern_removal_forest_type}*tif'))
-        tiles_to_delete.extend(glob.glob(f'*{cn.pattern_gain}*tif'))
+        tiles_to_delete.extend(glob.glob(f'*{cn.pattern_gain_ec2}*tif'))
         tiles_to_delete.extend(glob.glob(f'*{cn.pattern_soil_C_full_extent_2000}*tif'))
 
         uu.print_log(f'  Deleting {len(tiles_to_delete)} tiles...')

--- a/carbon_pools/mp_create_soil_C.py
+++ b/carbon_pools/mp_create_soil_C.py
@@ -28,7 +28,7 @@ from . import create_soil_C
 
 def mp_create_soil_C(tile_id_list, no_upload=None):
 
-    os.chdir(cn.docker_base_dir)
+    os.chdir(cn.docker_tile_dir)
     sensit_type = 'std'
 
     # If a full model run is specified, the correct set of tiles for the particular script is listed
@@ -52,13 +52,13 @@ def mp_create_soil_C(tile_id_list, no_upload=None):
     ### Soil carbon density
 
     uu.print_log("Downloading mangrove soil C rasters")
-    uu.s3_file_download(os.path.join(cn.mangrove_soil_C_dir, cn.name_mangrove_soil_C), cn.docker_base_dir, sensit_type)
+    uu.s3_file_download(os.path.join(cn.mangrove_soil_C_dir, cn.name_mangrove_soil_C), cn.docker_tile_dir, sensit_type)
 
     # For downloading all tiles in the input folders.
     input_files = [cn.mangrove_biomass_2000_dir]
 
     for input in input_files:
-        uu.s3_folder_download(input, cn.docker_base_dir, sensit_type)
+        uu.s3_folder_download(input, cn.docker_tile_dir, sensit_type)
 
     # Download raw mineral soil C density tiles.
     # First tries to download index.html.tmp from every folder, then goes back and downloads all the tifs in each folder
@@ -69,7 +69,7 @@ def mp_create_soil_C(tile_id_list, no_upload=None):
     uu.log_subprocess_output_full(cmd)
 
     uu.print_log("Unzipping mangrove soil C rasters...")
-    cmd = ['unzip', '-j', cn.name_mangrove_soil_C, '-d', cn.docker_base_dir]
+    cmd = ['unzip', '-j', cn.name_mangrove_soil_C, '-d', cn.docker_tile_dir]
     uu.log_subprocess_output_full(cmd)
 
     # Mangrove soil receives precedence over mineral soil
@@ -173,8 +173,8 @@ def mp_create_soil_C(tile_id_list, no_upload=None):
     ### Soil carbon density uncertainty
 
     # Separate directories for the 5% CI and 95% CI
-    dir_CI05 = '{0}{1}'.format(cn.docker_base_dir, 'CI05/')
-    dir_CI95 = '{0}{1}'.format(cn.docker_base_dir, 'CI95/')
+    dir_CI05 = '{0}{1}'.format(cn.docker_tile_dir, 'CI05/')
+    dir_CI95 = '{0}{1}'.format(cn.docker_tile_dir, 'CI95/')
     vrt_CI05 = 'mineral_soil_C_CI05.vrt'
     vrt_CI95 = 'mineral_soil_C_CI95.vrt'
     soil_C_stdev_global = 'soil_C_stdev.tif'

--- a/constants_and_names.py
+++ b/constants_and_names.py
@@ -203,7 +203,8 @@ gain_spreadsheet_dir = os.path.join(s3_base_dir, 'removal_rate_tables/')
 pattern_loss = 'GFW2021'
 loss_dir = 's3://gfw2-data/forest_change/hansen_2021/'
 
-# Hansen removals tiles based on canopy height (2001-2020)
+# Hansen removals tiles based on canopy height (2000-2020)
+# From https://www.frontiersin.org/articles/10.3389/frsen.2022.856903/full
 pattern_gain_data_lake = ''
 pattern_gain_ec2 = 'tree_cover_gain_2000_2020'
 gain_dir = 's3://gfw-data-lake/umd_tree_cover_gain_from_height/v202206/raster/epsg-4326/10/40000/gain/geotiff/'

--- a/constants_and_names.py
+++ b/constants_and_names.py
@@ -47,7 +47,7 @@ LOG_NOTE = ''
 loss_years = 21
 
 # Number of years in tree cover gain. If input cover gain raster is changed, this must be changed, too.
-gain_years = 12
+gain_years = 20
 
 # Biomass to carbon ratio for aboveground, belowground, and deadwood in non-mangrove forests (planted and non-planted)
 biomass_to_c_non_mangrove = 0.47
@@ -117,7 +117,7 @@ count = multiprocessing.cpu_count()
 s3_base_dir = 's3://gfw2-data/climate/carbon_model/'
 
 # Directory for all tiles in the Docker container
-docker_base_dir = '/usr/local/tiles/'
+docker_tile_dir = '/usr/local/tiles/'
 
 docker_tmp = '/usr/local/tmp'
 

--- a/data_prep/continent_ecozone_tiles.py
+++ b/data_prep/continent_ecozone_tiles.py
@@ -19,8 +19,7 @@ import rasterio
 import numpy as np
 import datetime
 from scipy import stats
-import sys
-sys.path.append('../')
+
 import constants_and_names as cn
 import universal_util as uu
 

--- a/data_prep/create_inputs_for_C_pools.py
+++ b/data_prep/create_inputs_for_C_pools.py
@@ -7,8 +7,7 @@ import datetime
 import rasterio
 import numpy as np
 from scipy import stats
-import sys
-sys.path.append('../')
+
 import universal_util as uu
 import constants_and_names as cn
 

--- a/data_prep/model_extent.py
+++ b/data_prep/model_extent.py
@@ -6,7 +6,6 @@ import datetime
 import numpy as np
 import os
 import rasterio
-import sys
 from memory_profiler import profile
 
 import constants_and_names as cn

--- a/data_prep/model_extent.py
+++ b/data_prep/model_extent.py
@@ -22,7 +22,7 @@ def model_extent(tile_id, pattern):
     """
 
     # I don't know why, but this needs to be here and not just in mp_model_extent
-    os.chdir(cn.docker_base_dir)
+    os.chdir(cn.docker_tile_dir)
 
     uu.print_log(f'Delineating model extent: {tile_id}')
 

--- a/data_prep/model_extent.py
+++ b/data_prep/model_extent.py
@@ -31,7 +31,7 @@ def model_extent(tile_id, pattern):
 
     # Names of the input tiles
     mangrove = f'{tile_id}_{cn.pattern_mangrove_biomass_2000}.tif'
-    gain = f'{cn.pattern_gain}_{tile_id}.tif'
+    gain = f'{tile_id}_{cn.pattern_gain_ec2}.tif'
     pre_2000_plantations = f'{tile_id}_{cn.pattern_plant_pre_2000}.tif'
 
     # Tree cover tile name depends on the sensitivity analysis.

--- a/data_prep/mp_continent_ecozone_tiles.py
+++ b/data_prep/mp_continent_ecozone_tiles.py
@@ -28,7 +28,7 @@ from . import continent_ecozone_tiles
 
 def mp_continent_ecozone_tiles(tile_id_list, run_date = None):
 
-    os.chdir(cn.docker_base_dir)
+    os.chdir(cn.docker_tile_dir)
 
     # If a full model run is specified, the correct set of tiles for the particular script is listed
     if tile_id_list == 'all':
@@ -42,7 +42,7 @@ def mp_continent_ecozone_tiles(tile_id_list, run_date = None):
 
 
     # if the continent-ecozone shapefile hasn't already been downloaded, it will be downloaded and unzipped
-    uu.s3_file_download(cn.cont_eco_s3_zip, cn.docker_base_dir, 'std')
+    uu.s3_file_download(cn.cont_eco_s3_zip, cn.docker_tile_dir, 'std')
 
     # Unzips ecozone shapefile
     cmd = ['unzip', cn.cont_eco_zip]

--- a/data_prep/mp_create_inputs_for_C_pools.py
+++ b/data_prep/mp_create_inputs_for_C_pools.py
@@ -15,7 +15,7 @@ from . import create_inputs_for_C_pools
 
 def mp_create_inputs_for_C_pools(tile_id_list, run_date = None, no_upload = None):
 
-    os.chdir(cn.docker_base_dir)
+    os.chdir(cn.docker_tile_dir)
     sensit_type = 'std'
 
     # If a full model run is specified, the correct set of tiles for the particular script is listed
@@ -40,10 +40,10 @@ def mp_create_inputs_for_C_pools(tile_id_list, run_date = None, no_upload = None
     input_files = [cn.fao_ecozone_raw_dir, cn.precip_raw_dir]
 
     for input in input_files:
-        uu.s3_file_download('{}'.format(input), cn.docker_base_dir, sensit_type)
+        uu.s3_file_download('{}'.format(input), cn.docker_tile_dir, sensit_type)
 
     uu.print_log("Unzipping boreal/temperate/tropical file (from FAO ecozones)")
-    cmd = ['unzip', '{}'.format(cn.pattern_fao_ecozone_raw), '-d', cn.docker_base_dir]
+    cmd = ['unzip', '{}'.format(cn.pattern_fao_ecozone_raw), '-d', cn.docker_tile_dir]
     uu.log_subprocess_output_full(cmd)
 
     uu.print_log("Copying elevation (srtm) files")

--- a/data_prep/mp_mangrove_processing.py
+++ b/data_prep/mp_mangrove_processing.py
@@ -14,7 +14,7 @@ import universal_util as uu
 
 def mp_mangrove_processing(tile_id_list, run_date = None, no_upload = None):
 
-    os.chdir(cn.docker_base_dir)
+    os.chdir(cn.docker_tile_dir)
 
     # If a full model run is specified, the correct set of tiles for the particular script is listed
     if tile_id_list == 'all':
@@ -26,7 +26,7 @@ def mp_mangrove_processing(tile_id_list, run_date = None, no_upload = None):
 
 
     # Downloads zipped raw mangrove files
-    uu.s3_file_download(os.path.join(cn.mangrove_biomass_raw_dir, cn.mangrove_biomass_raw_file), cn.docker_base_dir, 'std')
+    uu.s3_file_download(os.path.join(cn.mangrove_biomass_raw_dir, cn.mangrove_biomass_raw_file), cn.docker_tile_dir, 'std')
 
     # Unzips mangrove images into a flat structure (all tifs into main folder using -j argument)
     # NOTE: Unzipping some tifs (e.g., Australia, Indonesia) takes a very long time, so don't worry if the script appears to stop on that.

--- a/data_prep/mp_model_extent.py
+++ b/data_prep/mp_model_extent.py
@@ -74,8 +74,6 @@ def mp_model_extent(tile_id_list):
         pattern = values[0]
         uu.s3_flexible_download(directory, pattern, cn.docker_tile_dir, cn.SENSIT_TYPE, tile_id_list)
 
-    os.quit()
-
     # If the model run isn't the standard one, the output directory and file names are changed
     if cn.SENSIT_TYPE != 'std':
         uu.print_log('Changing output directory and file name pattern based on sensitivity analysis')

--- a/data_prep/mp_model_extent.py
+++ b/data_prep/mp_model_extent.py
@@ -27,7 +27,7 @@ def mp_model_extent(tile_id_list):
     :return: 1 set of tiles where pixels = 1 are included in the model and pixels = 0 are not included in the model
     """
 
-    os.chdir(cn.docker_base_dir)
+    os.chdir(cn.docker_tile_dir)
 
     # If a full model run is specified, the correct set of tiles for the particular script is listed
     if tile_id_list == 'all':
@@ -72,8 +72,9 @@ def mp_model_extent(tile_id_list):
     for key, values in download_dict.items():
         directory = key
         pattern = values[0]
-        uu.s3_flexible_download(directory, pattern, cn.docker_base_dir, cn.SENSIT_TYPE, tile_id_list)
+        uu.s3_flexible_download(directory, pattern, cn.docker_tile_dir, cn.SENSIT_TYPE, tile_id_list)
 
+    os.quit()
 
     # If the model run isn't the standard one, the output directory and file names are changed
     if cn.SENSIT_TYPE != 'std':

--- a/data_prep/mp_peatland_processing.py
+++ b/data_prep/mp_peatland_processing.py
@@ -23,7 +23,7 @@ from . import peatland_processing
 
 def mp_peatland_processing(tile_id_list):
 
-    os.chdir(cn.docker_base_dir)
+    os.chdir(cn.docker_tile_dir)
 
     # If a full model run is specified, the correct set of tiles for the particular script is listed
     if tile_id_list == 'all':
@@ -50,10 +50,10 @@ def mp_peatland_processing(tile_id_list):
     # below that latitude, the model uses Gumbricht (CIFOR) 2017.
 
     # Downloads peat layers
-    uu.s3_file_download(os.path.join(cn.peat_unprocessed_dir, cn.Gumbricht_peat_name), cn.docker_base_dir, cn.SENSIT_TYPE)
-    uu.s3_file_download(os.path.join(cn.peat_unprocessed_dir, cn.Miettinen_peat_zip), cn.docker_base_dir, cn.SENSIT_TYPE)
-    uu.s3_file_download(os.path.join(cn.peat_unprocessed_dir, cn.Xu_peat_zip), cn.docker_base_dir, cn.SENSIT_TYPE)
-    uu.s3_file_download(os.path.join(cn.peat_unprocessed_dir, cn.Dargie_name), cn.docker_base_dir, cn.SENSIT_TYPE)
+    uu.s3_file_download(os.path.join(cn.peat_unprocessed_dir, cn.Gumbricht_peat_name), cn.docker_tile_dir, cn.SENSIT_TYPE)
+    uu.s3_file_download(os.path.join(cn.peat_unprocessed_dir, cn.Miettinen_peat_zip), cn.docker_tile_dir, cn.SENSIT_TYPE)
+    uu.s3_file_download(os.path.join(cn.peat_unprocessed_dir, cn.Xu_peat_zip), cn.docker_tile_dir, cn.SENSIT_TYPE)
+    uu.s3_file_download(os.path.join(cn.peat_unprocessed_dir, cn.Dargie_name), cn.docker_tile_dir, cn.SENSIT_TYPE)
 
     # Unzips the Miettinen et al. peat shapefile (IDN and MYS)
     cmd = ['unzip', '-o', '-j', cn.Miettinen_peat_zip]

--- a/data_prep/mp_plantation_preparation.py
+++ b/data_prep/mp_plantation_preparation.py
@@ -142,7 +142,7 @@ import universal_util as uu
 
 def mp_plantation_preparation(gadm_index_shp, planted_index_shp, tile_id_list, run_date = None, no_upload = None):
 
-    os.chdir(cn.docker_base_dir)
+    os.chdir(cn.docker_tile_dir)
 
     # ## Not actually using this but leaving it here in case I want to add this functionality eventually. This
     # # was to allow users to run plantations for a select (contiguous) area rather than for the whole planet.
@@ -197,7 +197,7 @@ def mp_plantation_preparation(gadm_index_shp, planted_index_shp, tile_id_list, r
             uu.print_log("No GADM 1x1 tile index shapefile provided. Creating 1x1 planted forest country tiles from scratch...")
 
             # Downloads and unzips the GADM shapefile, which will be used to create 1x1 tiles of land areas
-            uu.s3_file_download(cn.gadm_path, cn.docker_base_dir)
+            uu.s3_file_download(cn.gadm_path, cn.docker_tile_dir)
             cmd = ['unzip', cn.gadm_zip]
             # Solution for adding subprocess output to log is from https://stackoverflow.com/questions/21953835/run-subprocess-and-print-output-to-logging
             process = Popen(cmd, stdout=PIPE, stderr=STDOUT)
@@ -230,7 +230,7 @@ def mp_plantation_preparation(gadm_index_shp, planted_index_shp, tile_id_list, r
 
             # Creates a shapefile of the boundaries of the 1x1 GADM tiles in countries with planted forests
             os.system('''gdaltindex {0}_{1}.shp GADM_*.tif'''.format(cn.pattern_gadm_1x1_index, uu.date_time_today))
-            cmd = ['aws', 's3', 'cp', cn.docker_base_dir, cn.gadm_plant_1x1_index_dir, '--exclude', '*', '--include', '{}*'.format(cn.pattern_gadm_1x1_index), '--recursive']
+            cmd = ['aws', 's3', 'cp', cn.docker_tile_dir, cn.gadm_plant_1x1_index_dir, '--exclude', '*', '--include', '{}*'.format(cn.pattern_gadm_1x1_index), '--recursive']
 
             # Solution for adding subprocess output to log is from https://stackoverflow.com/questions/21953835/run-subprocess-and-print-output-to-logging
             process = Popen(cmd, stdout=PIPE, stderr=STDOUT)
@@ -268,7 +268,7 @@ def mp_plantation_preparation(gadm_index_shp, planted_index_shp, tile_id_list, r
             uu.print_log('{}/'.format(gadm_index_path))
 
             # Copies the shapefile of 1x1 tiles of extent of countries with planted forests
-            cmd = ['aws', 's3', 'cp', '{}/'.format(gadm_index_path), cn.docker_base_dir, '--recursive', '--exclude', '*', '--include', '{}*'.format(gadm_index_shp)]
+            cmd = ['aws', 's3', 'cp', '{}/'.format(gadm_index_path), cn.docker_tile_dir, '--recursive', '--exclude', '*', '--include', '{}*'.format(gadm_index_shp)]
 
             # Solution for adding subprocess output to log is from https://stackoverflow.com/questions/21953835/run-subprocess-and-print-output-to-logging
             process = Popen(cmd, stdout=PIPE, stderr=STDOUT)
@@ -315,7 +315,7 @@ def mp_plantation_preparation(gadm_index_shp, planted_index_shp, tile_id_list, r
         # Creates a shapefile in which each feature is the extent of a plantation extent tile.
         # This index shapefile can be used the next time this process is run if starting with Entry Point 3.
         os.system('''gdaltindex {0}_{1}.shp plant_gain_*.tif'''.format(cn.pattern_plant_1x1_index, uu.date_time_today))
-        cmd = ['aws', 's3', 'cp', cn.docker_base_dir, cn.gadm_plant_1x1_index_dir, '--exclude', '*', '--include', '{}*'.format(cn.pattern_plant_1x1_index), '--recursive']
+        cmd = ['aws', 's3', 'cp', cn.docker_tile_dir, cn.gadm_plant_1x1_index_dir, '--exclude', '*', '--include', '{}*'.format(cn.pattern_plant_1x1_index), '--recursive']
 
         # Solution for adding subprocess output to log is from https://stackoverflow.com/questions/21953835/run-subprocess-and-print-output-to-logging
         process = Popen(cmd, stdout=PIPE, stderr=STDOUT)
@@ -331,7 +331,7 @@ def mp_plantation_preparation(gadm_index_shp, planted_index_shp, tile_id_list, r
         uu.print_log("Planted forest 1x1 tile index shapefile supplied. Using that to create 1x1 planted forest growth rate and forest type tiles...")
 
         # Copies the shapefile of 1x1 tiles of extent of planted forests
-        cmd = ['aws', 's3', 'cp', '{}/'.format(planted_index_path), cn.docker_base_dir, '--recursive', '--exclude', '*', '--include',
+        cmd = ['aws', 's3', 'cp', '{}/'.format(planted_index_path), cn.docker_tile_dir, '--recursive', '--exclude', '*', '--include',
                '{}*'.format(planted_index_shp), '--recursive']
 
         # Solution for adding subprocess output to log is from https://stackoverflow.com/questions/21953835/run-subprocess-and-print-output-to-logging

--- a/data_prep/mp_prep_other_inputs_annual.py
+++ b/data_prep/mp_prep_other_inputs_annual.py
@@ -109,7 +109,7 @@ def mp_prep_other_inputs(tile_id_list):
     if os.path.exists(TCLF_s3_dir):
         os.rmdir(TCLF_s3_dir)
     os.mkdir(TCLF_s3_dir)
-    cmd = ['aws', 's3', 'cp', cn.TCLF_raw_dir, TCLF_s3_dir, '--recursive','--request-payer', 'requester',
+    cmd = ['aws', 's3', 'sync', cn.TCLF_raw_dir, TCLF_s3_dir, '--request-payer', 'requester',
            '--include', '*', '--exclude', 'tiles*', '--exclude', '*geojason', '--exclude', '*Store']
     uu.log_subprocess_output_full(cmd)
 

--- a/data_prep/mp_prep_other_inputs_annual.py
+++ b/data_prep/mp_prep_other_inputs_annual.py
@@ -22,7 +22,7 @@ import universal_util as uu
 
 def mp_prep_other_inputs(tile_id_list):
 
-    os.chdir(cn.docker_base_dir)
+    os.chdir(cn.docker_tile_dir)
     sensit_type='std'
 
     # If a full model run is specified, the correct set of tiles for the particular script is listed
@@ -79,7 +79,7 @@ def mp_prep_other_inputs(tile_id_list):
     ### Drivers of tree cover loss processing
     uu.print_log("STEP 1: Preprocess drivers of tree cover loss")
 
-    uu.s3_file_download(os.path.join(cn.drivers_raw_dir, cn.pattern_drivers_raw), cn.docker_base_dir, sensit_type)
+    uu.s3_file_download(os.path.join(cn.drivers_raw_dir, cn.pattern_drivers_raw), cn.docker_tile_dir, sensit_type)
 
     # Creates tree cover loss driver tiles.
     # The raw driver tile should have NoData for unassigned drivers as opposed to 0 for unassigned drivers.
@@ -105,7 +105,7 @@ def mp_prep_other_inputs(tile_id_list):
 
     # TCLF is downloaded to its own folder because it doesn't have a standardized file name pattern.
     # This way, the entire contents of the TCLF folder can be worked on without mixing with other files.
-    TCLF_s3_dir = os.path.join(cn.docker_base_dir,'TCLF')
+    TCLF_s3_dir = os.path.join(cn.docker_tile_dir, 'TCLF')
     if os.path.exists(TCLF_s3_dir):
         os.rmdir(TCLF_s3_dir)
     os.mkdir(TCLF_s3_dir)

--- a/data_prep/mp_prep_other_inputs_one_off.py
+++ b/data_prep/mp_prep_other_inputs_one_off.py
@@ -26,7 +26,7 @@ from . import prep_other_inputs_one_off
 
 def mp_prep_other_inputs(tile_id_list):
 
-    os.chdir(cn.docker_base_dir)
+    os.chdir(cn.docker_tile_dir)
     sensit_type='std'
 
     # If a full model run is specified, the correct set of tiles for the particular script is listed

--- a/data_prep/mp_prep_other_inputs_one_off.py
+++ b/data_prep/mp_prep_other_inputs_one_off.py
@@ -96,7 +96,7 @@ def mp_prep_other_inputs(tile_id_list):
     # cmd = ['wget', '{}'.format(cn.annual_gain_AGC_natrl_forest_young_raw_URL), '-P', '{}'.format(cn.docker_base_dir)]
     # uu.log_subprocess_output_full(cmd)
     # uu.s3_file_download(cn.stdev_annual_gain_AGC_natrl_forest_young_raw_URL, cn.docker_base_dir, sensit_type)
-    # cmd = ['aws', 's3', 'cp', cn.primary_raw_dir, cn.docker_base_dir, '--recursive']
+    # cmd = ['aws', 's3', 'sync', cn.primary_raw_dir, cn.docker_base_dir]
     # uu.log_subprocess_output_full(cmd)
     #
     # uu.s3_flexible_download(cn.ifl_dir, cn.pattern_ifl, cn.docker_base_dir, sensit_type, tile_id_list)
@@ -271,7 +271,7 @@ def mp_prep_other_inputs(tile_id_list):
     ### Creates Hansen tiles of AGB:BGB based on Huang et al. 2021: https://essd.copernicus.org/articles/13/4263/2021/
 
     # uu.print_log("Downloading raw NetCDF files...")
-    # cmd = ['aws', 's3', 'cp', cn.AGB_BGB_Huang_raw_dir, '.', '--recursive']
+    # cmd = ['aws', 's3', 'sync', cn.AGB_BGB_Huang_raw_dir, '.']
     # uu.log_subprocess_output_full(cmd)
 
     # # Converts the AGB and BGB NetCDF files to global geotifs.

--- a/data_prep/peatland_processing.py
+++ b/data_prep/peatland_processing.py
@@ -6,12 +6,10 @@ Outside that band (>40N, since there are no tiles at >60S), Xu et al. 2018 is us
 Between 40N and 60S, Xu et al. 2018 is not used.
 '''
 
-from subprocess import Popen, PIPE, STDOUT, check_call
 import os
 import rasterio
 from shutil import copyfile
 import datetime
-import sys
 
 import constants_and_names as cn
 import universal_util as uu

--- a/data_prep/prep_other_inputs_one_off.py
+++ b/data_prep/prep_other_inputs_one_off.py
@@ -4,14 +4,12 @@ At this point, that is: climate zone, Indonesia/Malaysia plantations before 2000
 '''
 
 import datetime
-from subprocess import Popen, PIPE, STDOUT, check_call
 import rasterio
 import os
 import numpy as np
 from scipy import stats
 import os
-import sys
-sys.path.append('../')
+
 import constants_and_names as cn
 import universal_util as uu
 

--- a/emissions/calculate_gross_emissions.py
+++ b/emissions/calculate_gross_emissions.py
@@ -3,9 +3,7 @@ Function to call C++ executable that calculates gross emissions
 """
 
 import datetime
-import sys
 
-sys.path.append('../')
 import constants_and_names as cn
 import universal_util as uu
 

--- a/emissions/mp_calculate_gross_emissions.py
+++ b/emissions/mp_calculate_gross_emissions.py
@@ -50,9 +50,9 @@ def mp_calculate_gross_emissions(tile_id_list, emitted_pools):
         Units: Mg CO2e/ha over entire model period.
     """
 
-    os.chdir(cn.docker_base_dir)
+    os.chdir(cn.docker_tile_dir)
 
-    folder = cn.docker_base_dir
+    folder = cn.docker_tile_dir
 
     # If a full model run is specified, the correct set of tiles for the particular script is listed
     # If the tile_list argument is an s3 folder, the list of tiles in it is created
@@ -171,7 +171,7 @@ def mp_calculate_gross_emissions(tile_id_list, emitted_pools):
     for key, values in download_dict.items():
         directory = key
         output_pattern = values[0]
-        uu.s3_flexible_download(directory, output_pattern, cn.docker_base_dir, cn.SENSIT_TYPE, tile_id_list)
+        uu.s3_flexible_download(directory, output_pattern, cn.docker_tile_dir, cn.SENSIT_TYPE, tile_id_list)
 
 
     # If the model run isn't the standard one, the output directory and file names are changed

--- a/removals/US_removal_rates.py
+++ b/removals/US_removal_rates.py
@@ -18,7 +18,7 @@ def US_removal_rate_calc(tile_id, gain_table_group_region_age_dict, gain_table_g
     start = datetime.datetime.now()
 
     # Names of the input tiles
-    gain = f'{cn.pattern_gain}_{tile_id}.tif'
+    gain = f'{tile_id}_{cn.pattern_gain_ec2}.tif'
     US_age_cat = '{0}_{1}.tif'.format(tile_id, cn.pattern_age_cat_natrl_forest_US)
     US_forest_group = '{0}_{1}.tif'.format(tile_id, cn.pattern_FIA_forest_group_processed)
     US_region = '{0}_{1}.tif'.format(tile_id, cn.pattern_FIA_regions_processed)

--- a/removals/annual_gain_rate_AGC_BGC_all_forest_types.py
+++ b/removals/annual_gain_rate_AGC_BGC_all_forest_types.py
@@ -5,9 +5,7 @@ Function to create removal factor tiles with all removal factor sources combined
 import datetime
 import numpy as np
 import rasterio
-import sys
 
-sys.path.append('../')
 import constants_and_names as cn
 import universal_util as uu
 

--- a/removals/annual_gain_rate_IPCC_defaults.py
+++ b/removals/annual_gain_rate_IPCC_defaults.py
@@ -7,7 +7,6 @@ import numpy as np
 import rasterio
 import sys
 
-sys.path.append('../')
 import constants_and_names as cn
 import universal_util as uu
 

--- a/removals/annual_gain_rate_mangrove.py
+++ b/removals/annual_gain_rate_mangrove.py
@@ -7,7 +7,7 @@ import numpy as np
 import os
 import rasterio
 import sys
-sys.path.append('../')
+
 import constants_and_names as cn
 import universal_util as uu
 

--- a/removals/forest_age_category_IPCC.py
+++ b/removals/forest_age_category_IPCC.py
@@ -5,8 +5,7 @@ Function to create forest age category tiles
 import datetime
 import numpy as np
 import rasterio
-import sys
-sys.path.append('../')
+
 import constants_and_names as cn
 import universal_util as uu
 
@@ -181,16 +180,14 @@ def forest_age_category(tile_id, gain_table_dict, pattern):
                 dst_data[np.where((model_extent_window > 0) & (gain_window == 0) & (loss_window > 0) & (ifl_primary_window ==1))] = 3
 
                 # Gain-only pixels
-                # If there is gain, the pixel doesn't need biomass or canopy cover. It just needs to be outside of plantations and mangroves.
+                # If there is gain, the pixel doesn't need biomass or canopy cover.
                 # The role of model_extent_window here is to exclude the pre-2000 plantations.
                 dst_data[np.where((model_extent_window > 0) & (gain_window == 1) & (loss_window == 0))] = 1
 
                 # Pixels with loss and gain
-                # If there is gain with loss, the pixel doesn't need biomass or canopy cover. It just needs to be outside of plantations and mangroves.
+                # If there is gain with loss, the pixel doesn't need biomass or canopy cover.
                 # The role of model_extent_window here is to exclude the pre-2000 plantations.
-                dst_data[np.where((model_extent_window > 0) & (gain_window == 1) & (loss_window > (cn.gain_years)))] = 1
-                dst_data[np.where((model_extent_window > 0) & (gain_window == 1) & (loss_window > 0) & (loss_window <= (cn.gain_years/2)))] = 1
-                dst_data[np.where((model_extent_window > 0) & (gain_window == 1) & (loss_window > (cn.gain_years/2)) & (loss_window <= cn.gain_years))] = 1
+                dst_data[np.where((model_extent_window > 0) & (gain_window == 1) & (loss_window > 0))] = 1
 
             # For legal_Amazon_loss sensitivity analysis
             else:

--- a/removals/forest_age_category_IPCC.py
+++ b/removals/forest_age_category_IPCC.py
@@ -37,7 +37,7 @@ def forest_age_category(tile_id, gain_table_dict, pattern):
     uu.print_log(f'  Tile {tile_id} in tropics: {tropics}')
 
     # Names of the input tiles
-    gain = f'{cn.pattern_gain}_{tile_id}.tif'
+    gain = f'{tile_id}_{cn.pattern_gain_ec2}.tif'
     model_extent = uu.sensit_tile_rename(cn.SENSIT_TYPE, tile_id, cn.pattern_model_extent)
     ifl_primary = uu.sensit_tile_rename(cn.SENSIT_TYPE, tile_id, cn.pattern_ifl_primary)
     cont_eco = uu.sensit_tile_rename(cn.SENSIT_TYPE, tile_id, cn.pattern_cont_eco_processed)

--- a/removals/gain_year_count_all_forest_types.py
+++ b/removals/gain_year_count_all_forest_types.py
@@ -51,7 +51,8 @@ def create_gain_year_count_loss_only(tile_id):
         loss_outfilename = f'{tile_id}_gain_year_count_loss_only.tif'
         loss_outfilearg = f'--outfile={loss_outfilename}'
         cmd = ['gdal_calc.py', '-A', loss, '-B', gain, '-C', model_extent, loss_calc, loss_outfilearg,
-               '--NoDataValue=0', '--overwrite', '--co', 'COMPRESS=DEFLATE', '--type', 'Byte', '--quiet']
+               '--NoDataValue=0', '--overwrite', '--co', 'COMPRESS=DEFLATE', '--type', 'Byte', '--quiet',
+               '--hideNoData'] # Need --hideNoData because the non-gain pixels are NoData, not 0.
         uu.log_subprocess_output_full(cmd)
     else:
         uu.print_log(f'No loss tile found for {tile_id}. Skipping loss only pixel gain year count.')
@@ -161,7 +162,8 @@ def create_gain_year_count_no_change_standard(tile_id):
         no_change_outfilename = f'{tile_id}_gain_year_count_no_change.tif'
         no_change_outfilearg = f'--outfile={no_change_outfilename}'
         cmd = ['gdal_calc.py', '-A', loss, '-B', gain, '-C', model_extent, no_change_calc,
-               no_change_outfilearg, '--NoDataValue=0', '--overwrite', '--co', 'COMPRESS=DEFLATE', '--type', 'Byte', '--quiet']
+               no_change_outfilearg, '--NoDataValue=0', '--overwrite', '--co', 'COMPRESS=DEFLATE', '--type', 'Byte', '--quiet',
+               '--hideNoData'] # Need --hideNoData because the non-gain pixels are NoData, not 0.
         uu.log_subprocess_output_full(cmd)
     else:
         uu.print_log(f'  No loss tile found for {tile_id}. Not using it for no change pixel gain year count.')
@@ -169,7 +171,8 @@ def create_gain_year_count_no_change_standard(tile_id):
         no_change_outfilename = f'{tile_id}_gain_year_count_no_change.tif'
         no_change_outfilearg = f'--outfile={no_change_outfilename}'
         cmd = ['gdal_calc.py', '-A', gain, '-B', model_extent, no_change_calc,
-               no_change_outfilearg, '--NoDataValue=0', '--overwrite', '--co', 'COMPRESS=DEFLATE', '--type', 'Byte', '--quiet']
+               no_change_outfilearg, '--NoDataValue=0', '--overwrite', '--co', 'COMPRESS=DEFLATE', '--type', 'Byte', '--quiet',
+               '--hideNoData'] # Need --hideNoData because the non-gain pixels are NoData, not 0.
         uu.log_subprocess_output_full(cmd)
 
     # Prints information about the tile that was just processed

--- a/removals/gain_year_count_all_forest_types.py
+++ b/removals/gain_year_count_all_forest_types.py
@@ -6,9 +6,7 @@ import datetime
 import numpy as np
 import rasterio
 import os
-import sys
 
-sys.path.append('../')
 import constants_and_names as cn
 import universal_util as uu
 

--- a/removals/gain_year_count_all_forest_types.py
+++ b/removals/gain_year_count_all_forest_types.py
@@ -24,7 +24,7 @@ def tile_names(tile_id):
         loss = f'{tile_id}_{cn.pattern_Brazil_annual_loss_processed}.tif'
     else:
         loss = f'{cn.pattern_loss}_{tile_id}.tif'
-    gain = f'{cn.pattern_gain}_{tile_id}.tif'
+    gain = f'{tile_id}_{cn.pattern_gain_ec2}.tif'
     model_extent = uu.sensit_tile_rename(cn.SENSIT_TYPE, tile_id, cn.pattern_model_extent)
 
     return loss, gain, model_extent

--- a/removals/gross_removals_all_forest_types.py
+++ b/removals/gross_removals_all_forest_types.py
@@ -5,8 +5,6 @@ Function to create gross removals tiles
 import datetime
 import rasterio
 
-import sys
-sys.path.append('../')
 import constants_and_names as cn
 import universal_util as uu
 

--- a/removals/mp_US_removal_rates.py
+++ b/removals/mp_US_removal_rates.py
@@ -62,7 +62,7 @@ def mp_US_removal_rates(tile_id_list):
     uu.print_log(f'There are {str(len(tile_id_list))} tiles to process', "\n")
 
     # Files to download for this script
-    download_dict = {cn.gain_dir: [cn.pattern_gain],
+    download_dict = {cn.gain_dir: [cn.pattern_gain_data_lake],
                      cn.FIA_regions_processed_dir: [cn.pattern_FIA_regions_processed],
                      cn.FIA_forest_group_processed_dir: [cn.pattern_FIA_forest_group_processed],
                      cn.age_cat_natrl_forest_US_dir: [cn.pattern_age_cat_natrl_forest_US]

--- a/removals/mp_US_removal_rates.py
+++ b/removals/mp_US_removal_rates.py
@@ -52,7 +52,7 @@ from . import US_removal_rates
 
 def mp_US_removal_rates(tile_id_list):
 
-    os.chdir(cn.docker_base_dir)
+    os.chdir(cn.docker_tile_dir)
 
     # If a full model run is specified, the correct set of tiles for the particular script is listed
     if tile_id_list == 'all':
@@ -77,7 +77,7 @@ def mp_US_removal_rates(tile_id_list):
     for key, values in download_dict.items():
         dir = key
         pattern = values[0]
-        uu.s3_flexible_download(dir, pattern, cn.docker_base_dir, cn.SENSIT_TYPE, tile_id_list)
+        uu.s3_flexible_download(dir, pattern, cn.docker_tile_dir, cn.SENSIT_TYPE, tile_id_list)
 
 
     # If the model run isn't the standard one, the output directory and file names are changed
@@ -94,7 +94,7 @@ def mp_US_removal_rates(tile_id_list):
 
     # Table with US-specific removal rates
     # cmd = ['aws', 's3', 'cp', os.path.join(cn.gain_spreadsheet_dir, cn.table_US_removal_rate), cn.docker_base_dir, '--no-sign-request']
-    cmd = ['aws', 's3', 'cp', os.path.join(cn.gain_spreadsheet_dir, cn.table_US_removal_rate), cn.docker_base_dir]
+    cmd = ['aws', 's3', 'cp', os.path.join(cn.gain_spreadsheet_dir, cn.table_US_removal_rate), cn.docker_tile_dir]
     uu.log_subprocess_output_full(cmd)
 
 

--- a/removals/mp_annual_gain_rate_AGC_BGC_all_forest_types.py
+++ b/removals/mp_annual_gain_rate_AGC_BGC_all_forest_types.py
@@ -32,7 +32,7 @@ def mp_annual_gain_rate_AGC_BGC_all_forest_types(tile_id_list):
         Units: Mg carbon/ha/yr (including for standard deviation tiles)
     """
 
-    os.chdir(cn.docker_base_dir)
+    os.chdir(cn.docker_tile_dir)
 
     # If a full model run is specified, the correct set of tiles for the particular script is listed
     if tile_id_list == 'all':
@@ -78,7 +78,7 @@ def mp_annual_gain_rate_AGC_BGC_all_forest_types(tile_id_list):
     for key, values in download_dict.items():
         directory = key
         pattern = values[0]
-        uu.s3_flexible_download(directory, pattern, cn.docker_base_dir, cn.SENSIT_TYPE, tile_id_list)
+        uu.s3_flexible_download(directory, pattern, cn.docker_tile_dir, cn.SENSIT_TYPE, tile_id_list)
 
 
     # If the model run isn't the standard one, the output directory and file names are changed

--- a/removals/mp_annual_gain_rate_IPCC_defaults.py
+++ b/removals/mp_annual_gain_rate_IPCC_defaults.py
@@ -27,7 +27,7 @@ import constants_and_names as cn
 import universal_util as uu
 from . import annual_gain_rate_IPCC_defaults
 
-os.chdir(cn.docker_base_dir)
+os.chdir(cn.docker_tile_dir)
 
 def mp_annual_gain_rate_IPCC_defaults(tile_id_list):
     """
@@ -37,7 +37,7 @@ def mp_annual_gain_rate_IPCC_defaults(tile_id_list):
         Units: Mg biomass/ha/yr (including for standard deviation tiles)
     """
 
-    os.chdir(cn.docker_base_dir)
+    os.chdir(cn.docker_tile_dir)
     pd.options.mode.chained_assignment = None
 
 
@@ -80,11 +80,11 @@ def mp_annual_gain_rate_IPCC_defaults(tile_id_list):
     for key, values in download_dict.items():
         directory = key
         pattern = values[0]
-        uu.s3_flexible_download(directory, pattern, cn.docker_base_dir, cn.SENSIT_TYPE, tile_id_list)
+        uu.s3_flexible_download(directory, pattern, cn.docker_tile_dir, cn.SENSIT_TYPE, tile_id_list)
 
     # Table with IPCC Table 4.9 default removals rates
     # cmd = ['aws', 's3', 'cp', os.path.join(cn.gain_spreadsheet_dir, cn.gain_spreadsheet), cn.docker_base_dir, '--no-sign-request']
-    cmd = ['aws', 's3', 'cp', os.path.join(cn.gain_spreadsheet_dir, cn.gain_spreadsheet), cn.docker_base_dir]
+    cmd = ['aws', 's3', 'cp', os.path.join(cn.gain_spreadsheet_dir, cn.gain_spreadsheet), cn.docker_tile_dir]
     uu.log_subprocess_output_full(cmd)
 
 

--- a/removals/mp_annual_gain_rate_mangrove.py
+++ b/removals/mp_annual_gain_rate_mangrove.py
@@ -22,7 +22,7 @@ from . import annual_gain_rate_mangrove
 
 def mp_annual_gain_rate_mangrove(tile_id_list):
 
-    os.chdir(cn.docker_base_dir)
+    os.chdir(cn.docker_tile_dir)
     pd.options.mode.chained_assignment = None
 
 
@@ -58,12 +58,12 @@ def mp_annual_gain_rate_mangrove(tile_id_list):
     for key, values in download_dict.items():
         dir = key
         pattern = values[0]
-        uu.s3_flexible_download(dir, pattern, cn.docker_base_dir, cn.SENSIT_TYPE, tile_id_list)
+        uu.s3_flexible_download(dir, pattern, cn.docker_tile_dir, cn.SENSIT_TYPE, tile_id_list)
 
 
     # Table with IPCC Wetland Supplement Table 4.4 default mangrove removals rates
     # cmd = ['aws', 's3', 'cp', os.path.join(cn.gain_spreadsheet_dir, cn.gain_spreadsheet), cn.docker_base_dir, '--no-sign-request']
-    cmd = ['aws', 's3', 'cp', os.path.join(cn.gain_spreadsheet_dir, cn.gain_spreadsheet), cn.docker_base_dir]
+    cmd = ['aws', 's3', 'cp', os.path.join(cn.gain_spreadsheet_dir, cn.gain_spreadsheet), cn.docker_tile_dir]
     uu.log_subprocess_output_full(cmd)
 
 

--- a/removals/mp_forest_age_category_IPCC.py
+++ b/removals/mp_forest_age_category_IPCC.py
@@ -46,7 +46,7 @@ def mp_forest_age_category_IPCC(tile_id_list):
     # Files to download for this script.
     download_dict = {
                      cn.model_extent_dir: [cn.pattern_model_extent],
-                     cn.gain_dir: [cn.pattern_gain],
+                     cn.gain_dir: [cn.pattern_gain_data_lake],
                      cn.ifl_primary_processed_dir: [cn.pattern_ifl_primary],
                      cn.cont_eco_dir: [cn.pattern_cont_eco_processed]
     }

--- a/removals/mp_forest_age_category_IPCC.py
+++ b/removals/mp_forest_age_category_IPCC.py
@@ -32,7 +32,7 @@ def mp_forest_age_category_IPCC(tile_id_list):
     :return: set of tiles denoting three broad forest age categories: 1- young (<20), 2- middle, 3- old/primary
     """
 
-    os.chdir(cn.docker_base_dir)
+    os.chdir(cn.docker_tile_dir)
 
     # If a full model run is specified, the correct set of tiles for the particular script is listed
     if tile_id_list == 'all':
@@ -75,7 +75,7 @@ def mp_forest_age_category_IPCC(tile_id_list):
     for key, values in download_dict.items():
         directory = key
         pattern = values[0]
-        uu.s3_flexible_download(directory, pattern, cn.docker_base_dir, cn.SENSIT_TYPE, tile_id_list)
+        uu.s3_flexible_download(directory, pattern, cn.docker_tile_dir, cn.SENSIT_TYPE, tile_id_list)
 
 
     # If the model run isn't the standard one, the output directory and file names are changed
@@ -93,7 +93,7 @@ def mp_forest_age_category_IPCC(tile_id_list):
 
     # Table with IPCC Table 4.9 default removals rates
     # cmd = ['aws', 's3', 'cp', os.path.join(cn.gain_spreadsheet_dir, cn.gain_spreadsheet), cn.docker_base_dir, '--no-sign-request']
-    cmd = ['aws', 's3', 'cp', os.path.join(cn.gain_spreadsheet_dir, cn.gain_spreadsheet), cn.docker_base_dir]
+    cmd = ['aws', 's3', 'cp', os.path.join(cn.gain_spreadsheet_dir, cn.gain_spreadsheet), cn.docker_tile_dir]
     uu.log_subprocess_output_full(cmd)
 
 

--- a/removals/mp_gain_year_count_all_forest_types.py
+++ b/removals/mp_gain_year_count_all_forest_types.py
@@ -30,7 +30,7 @@ def mp_gain_year_count_all_forest_types(tile_id_list):
         Units: years.
     """
 
-    os.chdir(cn.docker_base_dir)
+    os.chdir(cn.docker_tile_dir)
 
     # If a full model run is specified, the correct set of tiles for the particular script is listed
     if tile_id_list == 'all':
@@ -65,7 +65,7 @@ def mp_gain_year_count_all_forest_types(tile_id_list):
     for key, values in download_dict.items():
         directory = key
         pattern = values[0]
-        uu.s3_flexible_download(directory, pattern, cn.docker_base_dir, cn.SENSIT_TYPE, tile_id_list)
+        uu.s3_flexible_download(directory, pattern, cn.docker_tile_dir, cn.SENSIT_TYPE, tile_id_list)
 
 
     # If the model run isn't the standard one, the output directory and file names are changed

--- a/removals/mp_gain_year_count_all_forest_types.py
+++ b/removals/mp_gain_year_count_all_forest_types.py
@@ -18,6 +18,7 @@ from functools import partial
 import multiprocessing
 import os
 import sys
+
 import constants_and_names as cn
 import universal_util as uu
 from . import gain_year_count_all_forest_types

--- a/removals/mp_gain_year_count_all_forest_types.py
+++ b/removals/mp_gain_year_count_all_forest_types.py
@@ -122,23 +122,23 @@ def mp_gain_year_count_all_forest_types(tile_id_list):
             pool.close()
             pool.join()
 
-        # Creates gain year count tiles using only pixels that had only gain
-        if cn.count == 96:
-            processes = 90   # 66 = 330 GB peak; 75 = 380 GB peak; 90 = 530 GB peak
-        else:
-            processes = int(cn.count/2)
-        uu.print_log(f'Gain year count gain only pixels max processors={processes}')
-        with multiprocessing.Pool(processes) as pool:
-            if cn.SENSIT_TYPE == 'maxgain':
-                pool.map(partial(gain_year_count_all_forest_types.create_gain_year_count_gain_only_maxgain),
-                         tile_id_list)
-            elif cn.SENSIT_TYPE == 'legal_Amazon_loss':
-                uu.print_log('Gain-only pixels do not apply to legal_Amazon_loss sensitivity analysis. Skipping this step.')
-            else:
-                pool.map(partial(gain_year_count_all_forest_types.create_gain_year_count_gain_only_standard),
-                         tile_id_list)
-            pool.close()
-            pool.join()
+        # # Creates gain year count tiles using only pixels that had only gain
+        # if cn.count == 96:
+        #     processes = 90   # 66 = 330 GB peak; 75 = 380 GB peak; 90 = 530 GB peak
+        # else:
+        #     processes = int(cn.count/2)
+        # uu.print_log(f'Gain year count gain only pixels max processors={processes}')
+        # with multiprocessing.Pool(processes) as pool:
+        #     if cn.SENSIT_TYPE == 'maxgain':
+        #         pool.map(partial(gain_year_count_all_forest_types.create_gain_year_count_gain_only_maxgain),
+        #                  tile_id_list)
+        #     elif cn.SENSIT_TYPE == 'legal_Amazon_loss':
+        #         uu.print_log('Gain-only pixels do not apply to legal_Amazon_loss sensitivity analysis. Skipping this step.')
+        #     else:
+        #         pool.map(partial(gain_year_count_all_forest_types.create_gain_year_count_gain_only_standard),
+        #                  tile_id_list)
+        #     pool.close()
+        #     pool.join()
 
         # Creates gain year count tiles using only pixels that had neither loss nor gain pixels
         if cn.count == 96:
@@ -156,21 +156,21 @@ def mp_gain_year_count_all_forest_types(tile_id_list):
             pool.close()
             pool.join()
 
-        # Creates gain year count tiles using only pixels that had only gain
-        if cn.count == 96:
-            processes = 90   # 66 = 370 GB peak; 88 = 430 GB peak; 90 = 550 GB peak
-        else:
-            processes = int(cn.count/2)
-        uu.print_log(f'Gain year count loss & gain pixels max processors={processes}')
-        with multiprocessing.Pool(processes) as pool:
-            if cn.SENSIT_TYPE == 'maxgain':
-                pool.map(partial(gain_year_count_all_forest_types.create_gain_year_count_loss_and_gain_maxgain),
-                         tile_id_list)
-            else:
-                pool.map(partial(gain_year_count_all_forest_types.create_gain_year_count_loss_and_gain_standard),
-                         tile_id_list)
-            pool.close()
-            pool.join()
+        # # Creates gain year count tiles using only pixels that had only gain
+        # if cn.count == 96:
+        #     processes = 90   # 66 = 370 GB peak; 88 = 430 GB peak; 90 = 550 GB peak
+        # else:
+        #     processes = int(cn.count/2)
+        # uu.print_log(f'Gain year count loss & gain pixels max processors={processes}')
+        # with multiprocessing.Pool(processes) as pool:
+        #     if cn.SENSIT_TYPE == 'maxgain':
+        #         pool.map(partial(gain_year_count_all_forest_types.create_gain_year_count_loss_and_gain_maxgain),
+        #                  tile_id_list)
+        #     else:
+        #         pool.map(partial(gain_year_count_all_forest_types.create_gain_year_count_loss_and_gain_standard),
+        #                  tile_id_list)
+        #     pool.close()
+        #     pool.join()
 
         # Combines the four above gain year count tiles for each Hansen tile into a single output tile
         if cn.count == 96:

--- a/removals/mp_gain_year_count_all_forest_types.py
+++ b/removals/mp_gain_year_count_all_forest_types.py
@@ -44,7 +44,7 @@ def mp_gain_year_count_all_forest_types(tile_id_list):
     # changed for a sensitivity analysis. This does not need to change based on what run is being done;
     # this assignment should be true for all sensitivity analyses and the standard model.
     download_dict = {
-        cn.gain_dir: [cn.pattern_gain],
+        cn.gain_dir: [cn.pattern_gain_data_lake],
         cn.model_extent_dir: [cn.pattern_model_extent]
     }
 

--- a/removals/mp_gain_year_count_all_forest_types.py
+++ b/removals/mp_gain_year_count_all_forest_types.py
@@ -122,23 +122,23 @@ def mp_gain_year_count_all_forest_types(tile_id_list):
             pool.close()
             pool.join()
 
-        # # Creates gain year count tiles using only pixels that had only gain
-        # if cn.count == 96:
-        #     processes = 90   # 66 = 330 GB peak; 75 = 380 GB peak; 90 = 530 GB peak
-        # else:
-        #     processes = int(cn.count/2)
-        # uu.print_log(f'Gain year count gain only pixels max processors={processes}')
-        # with multiprocessing.Pool(processes) as pool:
-        #     if cn.SENSIT_TYPE == 'maxgain':
-        #         pool.map(partial(gain_year_count_all_forest_types.create_gain_year_count_gain_only_maxgain),
-        #                  tile_id_list)
-        #     elif cn.SENSIT_TYPE == 'legal_Amazon_loss':
-        #         uu.print_log('Gain-only pixels do not apply to legal_Amazon_loss sensitivity analysis. Skipping this step.')
-        #     else:
-        #         pool.map(partial(gain_year_count_all_forest_types.create_gain_year_count_gain_only_standard),
-        #                  tile_id_list)
-        #     pool.close()
-        #     pool.join()
+        # Creates gain year count tiles using only pixels that had only gain
+        if cn.count == 96:
+            processes = 90   # 66 = 330 GB peak; 75 = 380 GB peak; 90 = 530 GB peak
+        else:
+            processes = int(cn.count/2)
+        uu.print_log(f'Gain year count gain only pixels max processors={processes}')
+        with multiprocessing.Pool(processes) as pool:
+            if cn.SENSIT_TYPE == 'maxgain':
+                pool.map(partial(gain_year_count_all_forest_types.create_gain_year_count_gain_only_maxgain),
+                         tile_id_list)
+            elif cn.SENSIT_TYPE == 'legal_Amazon_loss':
+                uu.print_log('Gain-only pixels do not apply to legal_Amazon_loss sensitivity analysis. Skipping this step.')
+            else:
+                pool.map(partial(gain_year_count_all_forest_types.create_gain_year_count_gain_only_standard),
+                         tile_id_list)
+            pool.close()
+            pool.join()
 
         # Creates gain year count tiles using only pixels that had neither loss nor gain pixels
         if cn.count == 96:
@@ -156,21 +156,21 @@ def mp_gain_year_count_all_forest_types(tile_id_list):
             pool.close()
             pool.join()
 
-        # # Creates gain year count tiles using only pixels that had only gain
-        # if cn.count == 96:
-        #     processes = 90   # 66 = 370 GB peak; 88 = 430 GB peak; 90 = 550 GB peak
-        # else:
-        #     processes = int(cn.count/2)
-        # uu.print_log(f'Gain year count loss & gain pixels max processors={processes}')
-        # with multiprocessing.Pool(processes) as pool:
-        #     if cn.SENSIT_TYPE == 'maxgain':
-        #         pool.map(partial(gain_year_count_all_forest_types.create_gain_year_count_loss_and_gain_maxgain),
-        #                  tile_id_list)
-        #     else:
-        #         pool.map(partial(gain_year_count_all_forest_types.create_gain_year_count_loss_and_gain_standard),
-        #                  tile_id_list)
-        #     pool.close()
-        #     pool.join()
+        # Creates gain year count tiles using only pixels that had only gain
+        if cn.count == 96:
+            processes = 90   # 66 = 370 GB peak; 88 = 430 GB peak; 90 = 550 GB peak
+        else:
+            processes = int(cn.count/2)
+        uu.print_log(f'Gain year count loss & gain pixels max processors={processes}')
+        with multiprocessing.Pool(processes) as pool:
+            if cn.SENSIT_TYPE == 'maxgain':
+                pool.map(partial(gain_year_count_all_forest_types.create_gain_year_count_loss_and_gain_maxgain),
+                         tile_id_list)
+            else:
+                pool.map(partial(gain_year_count_all_forest_types.create_gain_year_count_loss_and_gain_standard),
+                         tile_id_list)
+            pool.close()
+            pool.join()
 
         # Combines the four above gain year count tiles for each Hansen tile into a single output tile
         if cn.count == 96:

--- a/removals/mp_gross_removals_all_forest_types.py
+++ b/removals/mp_gross_removals_all_forest_types.py
@@ -27,7 +27,7 @@ def mp_gross_removals_all_forest_types(tile_id_list):
         Units: Mg CO2/ha over entire model period.
     """
 
-    os.chdir(cn.docker_base_dir)
+    os.chdir(cn.docker_tile_dir)
 
     # If a full model run is specified, the correct set of tiles for the particular script is listed
     if tile_id_list == 'all':
@@ -59,7 +59,7 @@ def mp_gross_removals_all_forest_types(tile_id_list):
     for key, values in download_dict.items():
         directory = key
         pattern = values[0]
-        uu.s3_flexible_download(directory, pattern, cn.docker_base_dir, cn.SENSIT_TYPE, tile_id_list)
+        uu.s3_flexible_download(directory, pattern, cn.docker_tile_dir, cn.SENSIT_TYPE, tile_id_list)
 
 
     # If the model run isn't the standard one, the output directory and file names are changed

--- a/run_full_model.py
+++ b/run_full_model.py
@@ -70,7 +70,7 @@ def main ():
     :return: Sets of output tiles for the selected stages
     """
 
-    os.chdir(cn.docker_base_dir)
+    os.chdir(cn.docker_tile_dir)
 
     # List of possible model stages to run (not including mangrove and planted forest stages)
     model_stages = ['all', 'model_extent', 'forest_age_category_IPCC', 'annual_removals_IPCC',

--- a/sensitivity_analysis/US_removal_rates.py
+++ b/sensitivity_analysis/US_removal_rates.py
@@ -53,7 +53,7 @@ def US_removal_rate_calc(tile_id, gain_table_group_region_age_dict, gain_table_g
     start = datetime.datetime.now()
 
     # Names of the input tiles
-    gain = f'{cn.pattern_gain}_{tile_id}.tif'
+    gain = f'{tile_id}_{cn.pattern_gain_ec2}.tif'
     annual_gain_standard = '{0}_{1}.tif'.format(tile_id, cn.pattern_annual_gain_AGB_IPCC_defaults)  # Used as the template extent/default for the US
     US_age_cat = '{0}_{1}.tif'.format(tile_id, cn.pattern_US_forest_age_cat_processed)
     US_forest_group = '{0}_{1}.tif'.format(tile_id, cn.pattern_FIA_forest_group_processed)

--- a/sensitivity_analysis/legal_AMZ_loss.py
+++ b/sensitivity_analysis/legal_AMZ_loss.py
@@ -14,7 +14,7 @@ def legal_Amazon_forest_age_category(tile_id, sensit_type, output_pattern):
     start = datetime.datetime.now()
 
     loss = '{0}_{1}.tif'.format(tile_id, cn.pattern_Brazil_annual_loss_processed)
-    gain = f'{cn.pattern_gain}_{tile_id}.tif'
+    gain = f'{tile_id}_{cn.pattern_gain_ec2}.tif'
     extent = '{0}_{1}.tif'.format(tile_id, cn.pattern_Brazil_forest_extent_2000_processed)
     biomass = uu.sensit_tile_rename(sensit_type, tile_id, cn.pattern_WHRC_biomass_2000_non_mang_non_planted)
     plantations = uu.sensit_tile_rename(sensit_type, tile_id, cn.pattern_planted_forest_type_unmasked)
@@ -98,7 +98,7 @@ def tile_names(tile_id, sensit_type):
 
     # Names of the input files
     loss = '{0}_{1}.tif'.format(tile_id, cn.pattern_Brazil_annual_loss_processed)
-    gain = f'{cn.pattern_gain}_{tile_id}.tif'
+    gain = f'{tile_id}_{cn.pattern_gain_ec2}.tif'
     extent = '{0}_{1}.tif'.format(tile_id, cn.pattern_Brazil_forest_extent_2000_processed)
     biomass = uu.sensit_tile_rename(sensit_type, tile_id, cn.pattern_WHRC_biomass_2000_non_mang_non_planted)
 

--- a/sensitivity_analysis/mp_Mekong_loss.py
+++ b/sensitivity_analysis/mp_Mekong_loss.py
@@ -20,7 +20,7 @@ def main ():
     # Create the output log
     uu.initiate_log()
 
-    os.chdir(cn.docker_base_dir)
+    os.chdir(cn.docker_tile_dir)
 
     # List of tiles that could be run. This list is only used to create the FIA region tiles if they don't already exist.
     tile_id_list = uu.tile_list_s3(cn.WHRC_biomass_2000_unmasked_dir)
@@ -30,7 +30,7 @@ def main ():
 
 
     # Downloads the Mekong loss folder. Each year of loss has its own raster
-    uu.s3_folder_download(cn.Mekong_loss_raw_dir, cn.docker_base_dir, sensit_type)
+    uu.s3_folder_download(cn.Mekong_loss_raw_dir, cn.docker_tile_dir, sensit_type)
 
     # The list of all annual loss rasters
     annual_loss_list = glob.glob('Loss_20*tif')

--- a/sensitivity_analysis/mp_Saatchi_biomass_prep.py
+++ b/sensitivity_analysis/mp_Saatchi_biomass_prep.py
@@ -20,7 +20,7 @@ def main ():
     # Create the output log
     uu.initiate_log()
 
-    os.chdir(cn.docker_base_dir)
+    os.chdir(cn.docker_tile_dir)
 
     # The list of tiles to iterate through
     tile_id_list = uu.tile_list_s3(cn.WHRC_biomass_2000_unmasked_dir)

--- a/sensitivity_analysis/mp_US_removal_rates.py
+++ b/sensitivity_analysis/mp_US_removal_rates.py
@@ -48,7 +48,7 @@ def main ():
     os.chdir(cn.docker_tile_dir)
 
     # Files to download for this script.
-    download_dict = {cn.gain_dir: [cn.pattern_gain],
+    download_dict = {cn.gain_dir: [cn.pattern_gain_data_lake],
                      cn.annual_gain_AGB_IPCC_defaults_dir: [cn.pattern_annual_gain_AGB_IPCC_defaults],
                      cn.BGB_AGB_ratio_dir: [cn.pattern_BGB_AGB_ratio]
     }

--- a/sensitivity_analysis/mp_US_removal_rates.py
+++ b/sensitivity_analysis/mp_US_removal_rates.py
@@ -45,7 +45,7 @@ def main ():
     # Create the output log
     uu.initiate_log()
 
-    os.chdir(cn.docker_base_dir)
+    os.chdir(cn.docker_tile_dir)
 
     # Files to download for this script.
     download_dict = {cn.gain_dir: [cn.pattern_gain],
@@ -73,11 +73,11 @@ def main ():
     # Only creates FIA region tiles if they don't already exist on s3.
     if FIA_regions_tile_count == 16:
         uu.print_log("FIA region tiles already created. Copying to s3 now...")
-        uu.s3_flexible_download(cn.FIA_regions_processed_dir, cn.pattern_FIA_regions_processed, cn.docker_base_dir, 'std', 'all')
+        uu.s3_flexible_download(cn.FIA_regions_processed_dir, cn.pattern_FIA_regions_processed, cn.docker_tile_dir, 'std', 'all')
 
     else:
         uu.print_log("FIA region tiles do not exist. Creating tiles, then copying to s3 for future use...")
-        uu.s3_file_download(os.path.join(cn.FIA_regions_raw_dir, cn.name_FIA_regions_raw), cn.docker_base_dir, 'std')
+        uu.s3_file_download(os.path.join(cn.FIA_regions_raw_dir, cn.name_FIA_regions_raw), cn.docker_tile_dir, 'std')
 
         cmd = ['unzip', '-o', '-j', cn.name_FIA_regions_raw]
         # Solution for adding subprocess output to log is from https://stackoverflow.com/questions/21953835/run-subprocess-and-print-output-to-logging
@@ -91,7 +91,7 @@ def main ():
 
 
     # List of FIA region tiles on the spot machine. Only this list is used for the rest of the script.
-    US_tile_list = uu.tile_list_spot_machine(cn.docker_base_dir, '{}.tif'.format(cn.pattern_FIA_regions_processed))
+    US_tile_list = uu.tile_list_spot_machine(cn.docker_tile_dir, '{}.tif'.format(cn.pattern_FIA_regions_processed))
     US_tile_id_list = [i[0:8] for i in US_tile_list]
     # US_tile_id_list = ['50N_130W']    # For testing
     uu.print_log(US_tile_id_list)
@@ -109,7 +109,7 @@ def main ():
 
     else:
         uu.print_log("Southern forest age category tiles do not exist. Creating tiles, then copying to s3 for future use...")
-        uu.s3_file_download(os.path.join(cn.US_forest_age_cat_raw_dir, cn.name_US_forest_age_cat_raw), cn.docker_base_dir, 'std')
+        uu.s3_file_download(os.path.join(cn.US_forest_age_cat_raw_dir, cn.name_US_forest_age_cat_raw), cn.docker_tile_dir, 'std')
 
         # Converts the national forest age category raster to Hansen tiles
         source_raster = cn.name_US_forest_age_cat_raw
@@ -132,7 +132,7 @@ def main ():
 
     else:
         uu.print_log("FIA forest group tiles do not exist. Creating tiles, then copying to s3 for future use...")
-        uu.s3_file_download(os.path.join(cn.FIA_forest_group_raw_dir, cn.name_FIA_forest_group_raw), cn.docker_base_dir, 'std')
+        uu.s3_file_download(os.path.join(cn.FIA_forest_group_raw_dir, cn.name_FIA_forest_group_raw), cn.docker_tile_dir, 'std')
 
         # Converts the national forest group raster to Hansen forest group tiles
         source_raster = cn.name_FIA_forest_group_raw
@@ -149,13 +149,13 @@ def main ():
     for key, values in download_dict.items():
         dir = key
         pattern = values[0]
-        uu.s3_flexible_download(dir, pattern, cn.docker_base_dir, sensit_type, US_tile_id_list)
+        uu.s3_flexible_download(dir, pattern, cn.docker_tile_dir, sensit_type, US_tile_id_list)
 
 
 
     # Table with US-specific removal rates
     # cmd = ['aws', 's3', 'cp', os.path.join(cn.gain_spreadsheet_dir, cn.table_US_removal_rate), cn.docker_base_dir, '--no-sign-request']
-    cmd = ['aws', 's3', 'cp', os.path.join(cn.gain_spreadsheet_dir, cn.table_US_removal_rate), cn.docker_base_dir]
+    cmd = ['aws', 's3', 'cp', os.path.join(cn.gain_spreadsheet_dir, cn.table_US_removal_rate), cn.docker_tile_dir]
 
     # Solution for adding subprocess output to log is from https://stackoverflow.com/questions/21953835/run-subprocess-and-print-output-to-logging
     process = Popen(cmd, stdout=PIPE, stderr=STDOUT)

--- a/sensitivity_analysis/mp_legal_AMZ_loss.py
+++ b/sensitivity_analysis/mp_legal_AMZ_loss.py
@@ -129,7 +129,7 @@ def main ():
         uu.print_log(f'There are {str(len(tile_id_list))} tiles to process', "\n")
 
         # Downloads input rasters and lists them
-        cmd = ['aws', 's3', 'cp', cn.Brazil_annual_loss_raw_dir, '.', '--recursive']
+        cmd = ['aws', 's3', 'sync', cn.Brazil_annual_loss_raw_dir, '.']
         uu.log_subprocess_output_full(cmd)
 
         uu.print_log("Input loss rasters downloaded. Getting resolution of recent raster...")

--- a/sensitivity_analysis/mp_legal_AMZ_loss.py
+++ b/sensitivity_analysis/mp_legal_AMZ_loss.py
@@ -28,7 +28,7 @@ def main ():
     # Create the output log
     uu.initiate_log()
 
-    os.chdir(cn.docker_base_dir)
+    os.chdir(cn.docker_tile_dir)
 
     Brazil_stages = ['all', 'create_forest_extent', 'create_loss']
 
@@ -81,7 +81,7 @@ def main ():
         uu.print_log(f'There are {str(len(tile_id_list))} tiles to process', "\n")
 
         # Downloads input rasters and lists them
-        uu.s3_folder_download(cn.Brazil_forest_extent_2000_raw_dir, cn.docker_base_dir, sensit_type)
+        uu.s3_folder_download(cn.Brazil_forest_extent_2000_raw_dir, cn.docker_tile_dir, sensit_type)
         raw_forest_extent_inputs = glob.glob('*_AMZ_warped_*tif')   # The list of tiles to merge
 
         # Gets the resolution of a more recent PRODES raster, which has a higher resolution. The merged output matches that.
@@ -200,7 +200,7 @@ def main ():
         for key, values in download_dict.items():
             dir = key
             pattern = values[0]
-            uu.s3_flexible_download(dir, pattern, cn.docker_base_dir, sensit_type, tile_id_list)
+            uu.s3_flexible_download(dir, pattern, cn.docker_tile_dir, sensit_type, tile_id_list)
 
 
         # If the model run isn't the standard one, the output directory and file names are changed
@@ -257,7 +257,7 @@ def main ():
         for key, values in download_dict.items():
             dir = key
             pattern = values[0]
-            uu.s3_flexible_download(dir, pattern, cn.docker_base_dir, sensit_type, tile_id_list)
+            uu.s3_flexible_download(dir, pattern, cn.docker_tile_dir, sensit_type, tile_id_list)
 
 
         # If the model run isn't the standard one, the output directory and file names are changed
@@ -337,11 +337,11 @@ def main ():
         for key, values in download_dict.items():
             dir = key
             pattern = values[0]
-            uu.s3_flexible_download(dir, pattern, cn.docker_base_dir, sensit_type, tile_id_list)
+            uu.s3_flexible_download(dir, pattern, cn.docker_tile_dir, sensit_type, tile_id_list)
 
 
         # Table with IPCC Table 4.9 default removals rates
-        cmd = ['aws', 's3', 'cp', os.path.join(cn.gain_spreadsheet_dir, cn.gain_spreadsheet), cn.docker_base_dir]
+        cmd = ['aws', 's3', 'cp', os.path.join(cn.gain_spreadsheet_dir, cn.gain_spreadsheet), cn.docker_tile_dir]
 
         # Solution for adding subprocess output to log is from https://stackoverflow.com/questions/21953835/run-subprocess-and-print-output-to-logging
         process = Popen(cmd, stdout=PIPE, stderr=STDOUT)
@@ -453,7 +453,7 @@ def main ():
         for key, values in download_dict.items():
             dir = key
             pattern = values[0]
-            uu.s3_flexible_download(dir, pattern, cn.docker_base_dir, sensit_type, tile_id_list)
+            uu.s3_flexible_download(dir, pattern, cn.docker_tile_dir, sensit_type, tile_id_list)
 
 
         # Calculates cumulative aboveground carbon removals in non-mangrove planted forests
@@ -525,7 +525,7 @@ def main ():
         for key, values in download_dict.items():
             dir = key
             pattern = values[0]
-            uu.s3_flexible_download(dir, pattern, cn.docker_base_dir, sensit_type, tile_id_list)
+            uu.s3_flexible_download(dir, pattern, cn.docker_tile_dir, sensit_type, tile_id_list)
 
 
         # For multiprocessing
@@ -593,7 +593,7 @@ def main ():
         for key, values in download_dict.items():
             dir = key
             pattern = values[0]
-            uu.s3_flexible_download(dir, pattern, cn.docker_base_dir, sensit_type, tile_id_list)
+            uu.s3_flexible_download(dir, pattern, cn.docker_tile_dir, sensit_type, tile_id_list)
 
         # If the model run isn't the standard one, the output directory and file names are changed
         if sensit_type != 'std':
@@ -603,7 +603,7 @@ def main ():
 
 
         # Table with IPCC Wetland Supplement Table 4.4 default mangrove removals rates
-        cmd = ['aws', 's3', 'cp', os.path.join(cn.gain_spreadsheet_dir, cn.gain_spreadsheet), cn.docker_base_dir]
+        cmd = ['aws', 's3', 'cp', os.path.join(cn.gain_spreadsheet_dir, cn.gain_spreadsheet), cn.docker_tile_dir]
 
         # Solution for adding subprocess output to log is from https://stackoverflow.com/questions/21953835/run-subprocess-and-print-output-to-logging
         process = Popen(cmd, stdout=PIPE, stderr=STDOUT)

--- a/sensitivity_analysis/mp_legal_AMZ_loss.py
+++ b/sensitivity_analysis/mp_legal_AMZ_loss.py
@@ -182,7 +182,7 @@ def main ():
 
         # Files to download for this script.
         download_dict = {cn.Brazil_annual_loss_processed_dir: [cn.pattern_Brazil_annual_loss_processed],
-                         cn.gain_dir: [cn.pattern_gain],
+                         cn.gain_dir: [cn.pattern_gain_data_lake],
                          cn.WHRC_biomass_2000_non_mang_non_planted_dir: [cn.pattern_WHRC_biomass_2000_non_mang_non_planted],
                          cn.planted_forest_type_unmasked_dir: [cn.pattern_planted_forest_type_unmasked],
                          cn.mangrove_biomass_2000_dir: [cn.pattern_mangrove_biomass_2000],
@@ -239,7 +239,7 @@ def main ():
         # Files to download for this script.
         download_dict = {
             cn.Brazil_annual_loss_processed_dir: [cn.pattern_Brazil_annual_loss_processed],
-            cn.gain_dir: [cn.pattern_gain],
+            cn.gain_dir: [cn.pattern_gain_data_lake],
             cn.WHRC_biomass_2000_non_mang_non_planted_dir: [cn.pattern_WHRC_biomass_2000_non_mang_non_planted],
             cn.planted_forest_type_unmasked_dir: [cn.pattern_planted_forest_type_unmasked],
             cn.mangrove_biomass_2000_dir: [cn.pattern_mangrove_biomass_2000],
@@ -563,7 +563,7 @@ def main ():
             cn.precip_processed_dir: [cn.pattern_precip],
             cn.elevation_processed_dir: [cn.pattern_elevation],
             cn.soil_C_full_extent_2000_dir: [cn.pattern_soil_C_full_extent_2000],
-            cn.gain_dir: [cn.pattern_gain],
+            cn.gain_dir: [cn.pattern_gain_data_lake],
             cn.cumul_gain_AGCO2_mangrove_dir: [cn.pattern_cumul_gain_AGCO2_mangrove],
             cn.cumul_gain_AGCO2_planted_forest_non_mangrove_dir: [cn.pattern_cumul_gain_AGCO2_planted_forest_non_mangrove],
             cn.cumul_gain_AGCO2_natrl_forest_dir: [cn.pattern_cumul_gain_AGCO2_natrl_forest],

--- a/universal_util.py
+++ b/universal_util.py
@@ -716,7 +716,7 @@ def s3_folder_download(source, dest, sensit_type, pattern = None):
         # Downloads non-data-lake inputs
         else:
 
-            cmd = ['aws', 's3', 'cp', source, dest, '--no-sign-request', '--recursive', '--exclude', '*tiled/*',
+            cmd = ['aws', 's3', 'sync', source, dest, '--no-sign-request', '--recursive', '--exclude', '*tiled/*',
                    '--exclude', '*geojason', '--exclude', '*vrt', '--exclude', '*csv', '--no-progress']
             # cmd = ['aws', 's3', 'cp', source, dest, '--no-sign-request', '--recursive', '--exclude', '*tiled/*',
             #        '--exclude', '*geojason', '--exclude', '*vrt', '--exclude', '*csv']

--- a/universal_util.py
+++ b/universal_util.py
@@ -686,7 +686,7 @@ def s3_folder_download(source, dest, sensit_type, pattern = None):
             print_log(f'Tiles with pattern {pattern} are already on spot machine. Not downloading.', "\n")
             # return
 
-        print_log(f'Tiles with pattern {pattern} are not on spot machine. Downloading...')
+        # print_log(f'Tiles with pattern {pattern} are not on spot machine. Downloading...')
 
         # Downloads tile sets from the gfw-data-lake.
         # They need a special process because they don't have a tile pattern on the data-lake,

--- a/universal_util.py
+++ b/universal_util.py
@@ -693,6 +693,9 @@ def s3_folder_download(source, dest, sensit_type, pattern = None):
         # so I have to download them into their own folder and then give them a pattern while moving them to the main folder
         if 'gfw-data-lake' in source:
 
+            # Deletes special folder for downloads from data-lake
+            os.rmdir(os.path.join(dest, 'data-lake-downloads'))
+
             # Special folder for the tile set that doesn't have a pattern when downloaded
             os.mkdir(os.path.join(dest, 'data-lake-downloads'))
 

--- a/universal_util.py
+++ b/universal_util.py
@@ -696,7 +696,7 @@ def s3_folder_download(source, dest, sensit_type, pattern = None):
             # Special folder for the tile set that doesn't have a pattern when downloaded
             os.mkdir(os.path.join(dest, 'data-lake-downloads'))
 
-            cmd = ['aws', 's3', 'cp', source, os.path.join(dest, 'data-lake-downloads'),
+            cmd = ['aws', 's3', 'sync', source, os.path.join(dest, 'data-lake-downloads'),
                    '--request-payer', 'requester', '--recursive', '--exclude', '*xml',
                    '--exclude', '*geojason', '--exclude', '*vrt', '--exclude', '*csv', '--no-progress']
             log_subprocess_output_full(cmd)

--- a/universal_util.py
+++ b/universal_util.py
@@ -684,7 +684,7 @@ def s3_folder_download(source, dest, sensit_type, pattern = None):
         # If there are as many tiles on the spot machine with the relevant pattern as there are on s3, no tiles are downloaded
         if local_tile_count == s3_count:
             print_log(f'Tiles with pattern {pattern} are already on spot machine. Not downloading.', "\n")
-            return
+            # return
 
         print_log(f'Tiles with pattern {pattern} are not on spot machine. Downloading...')
 

--- a/universal_util.py
+++ b/universal_util.py
@@ -703,7 +703,7 @@ def s3_folder_download(source, dest, sensit_type, pattern = None):
 
             # Copies pattern-less tiles from their special folder to main tile folder and renames them with
             # pattern along the way
-            uu.print_log("Copying tiles to main tile folder")
+            print_log("Copying tiles to main tile folder")
 
             for filename in os.listdir(os.path.join(dest, 'data-lake-downloads')):
 

--- a/universal_util.py
+++ b/universal_util.py
@@ -725,8 +725,6 @@ def s3_folder_download(source, dest, sensit_type, pattern = None):
 
         print_log("\n")
 
-        os.quit()
-
 
 # Downloads individual tiles from s3
 # Source=source file on s3

--- a/universal_util.py
+++ b/universal_util.py
@@ -523,7 +523,7 @@ def count_tiles_s3(source, pattern=None):
 
             # For gain, tcd, pixel area, and loss tiles (and their rewindowed versions),
             # which have the tile_id after the the pattern
-            if pattern in [cn.pattern_gain, cn.pattern_tcd, cn.pattern_pixel_area, cn.pattern_loss]:
+            if pattern in [cn.pattern_gain_data_lake, cn.pattern_tcd, cn.pattern_pixel_area, cn.pattern_loss]:
                 if tile_name.endswith('.tif'):
                     tile_id = get_tile_id(tile_name)
                     file_list.append(tile_id)
@@ -603,7 +603,7 @@ def s3_folder_download(source, dest, sensit_type, pattern = None):
     local_tile_count = len(glob.glob(f'*{pattern}*.tif'))
 
     # For tile types that have the tile_id after the pattern
-    if pattern in [cn.pattern_gain, cn.pattern_tcd, cn.pattern_pixel_area, cn.pattern_loss]:
+    if pattern in [cn.pattern_gain_data_lake, cn.pattern_tcd, cn.pattern_pixel_area, cn.pattern_loss]:
 
         local_tile_count = len(glob.glob(f'{pattern}*.tif'))
 
@@ -1340,7 +1340,7 @@ def rewindow(tile_id, download_pattern_name):
     start = datetime.datetime.now()
 
     # These tiles have the tile_id after the pattern
-    if download_pattern_name in [cn.pattern_pixel_area, cn.pattern_tcd, cn.pattern_gain, cn.pattern_loss]:
+    if download_pattern_name in [cn.pattern_pixel_area, cn.pattern_tcd, cn.pattern_loss]:
         in_tile = f'{download_pattern_name}_{tile_id}.tif'
         out_tile = f'{download_pattern_name}_rewindow_{tile_id}.tif'
 

--- a/universal_util.py
+++ b/universal_util.py
@@ -697,7 +697,7 @@ def s3_folder_download(source, dest, sensit_type, pattern = None):
             os.mkdir(os.path.join(dest, 'data-lake-downloads'))
 
             cmd = ['aws', 's3', 'sync', source, os.path.join(dest, 'data-lake-downloads'),
-                   '--request-payer', 'requester', '--recursive', '--exclude', '*xml',
+                   '--request-payer', 'requester', '--exclude', '*xml',
                    '--exclude', '*geojason', '--exclude', '*vrt', '--exclude', '*csv', '--no-progress']
             log_subprocess_output_full(cmd)
 
@@ -716,7 +716,7 @@ def s3_folder_download(source, dest, sensit_type, pattern = None):
         # Downloads non-data-lake inputs
         else:
 
-            cmd = ['aws', 's3', 'sync', source, dest, '--no-sign-request', '--recursive', '--exclude', '*tiled/*',
+            cmd = ['aws', 's3', 'sync', source, dest, '--no-sign-request', '--exclude', '*tiled/*',
                    '--exclude', '*geojason', '--exclude', '*vrt', '--exclude', '*csv', '--no-progress']
             # cmd = ['aws', 's3', 'cp', source, dest, '--no-sign-request', '--recursive', '--exclude', '*tiled/*',
             #        '--exclude', '*geojason', '--exclude', '*vrt', '--exclude', '*csv']


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Make sure you are requesting to pull a topic/feature/bugfix branch (right side). Don't request your master!
- [x] Make sure you are making a pull request against the develop branch (left side). Also you should start your branch off our develop.
- [x] Check the commit's or even all commits' message styles matches our requested structure.
- [x] Check your code additions will fail neither code linting checks nor unit test.

## Pull request type

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
1. Tree cover gain is from the original 2000-2012 product, so no tree cover gain after 2012 is captured in the model.
2. Folders from s3 are downloaded using `aws s3 cp [source] [dest] --recursive`. To make sure that files that have already been downloaded aren't being downloaded again, uu.s3_folder_download() checks if there are the same number of files in s3 and the ec2 instance. If there's the same number, tiles are not downloaded from s3 since they're already on ec2.

## What is the new behavior?
1. Tree cover gain is from the 2000-2020 land cover change product (https://www.frontiersin.org/articles/10.3389/frsen.2022.856903/full). This primarily involved just swapping out the gain tiles. The rules about forest age category and gain year count didn't change at all with the expansion of tree cover gain from 2000-2012 to 2000-2020. However, I did have to change uu.s3_file_download() and uu.s3_folder_download() to accommodate downloads from the gfw-data-lake (as opposed to gfw2-data), where the tiles don't have a pattern (just [tile_id].tif). 
2. Folders from s3 are now being downloaded using `aws s3 sync [source] [dest]`. This keeps tiles that are already downloaded to the ec2 instance from being downloaded again. I still have the the download utilities count how many tiles of the specified pattern are on ec2 and s3 but it'll proceed with downloading all the tiles that haven't been downloaded already.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Tested by running all model stages on 00N_000E and checking the results for forest age category and gain year count in gain-only and gain-loss tiles. Noticed an issue with the gain year count in loss-only and no-change tiles because of the Hansen gain tiles using NoData instead of 0. Also confirmed that forest extent gross removals and net flux outputs are correct. 

The forest age category and gain year count rules actually didn't change when tree cover went from 2000-2012 to 2000-2020 but I did change the schematics a little. Theoretically the gain year count rules could be changed a bit for loss-gain pixels but it's too complicated to do at this point, so I'm just going to keep the same loss-gain equation for gain year count as the original model. The possible change would be that if TCL is very late in the series (say, after 2015), tree cover gain presumably wouldn't occur after that; it would occur before. So for late TCL (say, after 2015), perhaps half of the years before TCL should be considered as having removals and none of the years after having removals. But it's a marginal change, would require complicated changes to AGC pool creation (where AGC is created for loss-gain pixels), and has additional judgement calls to make, like what the cutoff year for "late TCL" should be at which the rule for loss-gain gain year count would change from what I'm currently using.

Schematics at: https://onewri-my.sharepoint.com/:p:/g/personal/david_gibbs_wri_org/EecqazkbIR5Btyq-39D08FEBHgjQ1oJOJ-usr5GapoiQgA?e=iXtaVV
