### PR TITLE
Feature/include pre 2000 plantations

### DIFF
--- a/analyses/mp_derivative_outputs.py
+++ b/analyses/mp_derivative_outputs.py
@@ -144,7 +144,8 @@ def mp_derivative_outputs(tile_id_list_outer):
             uu.exception_log('No output patterns found for input pattern. Please check.')
 
 
-        ### STEP 1: Creates the per-pixel and forest extent 0.00025x0.00025 deg derivative outputs
+        ### STEP 1: Creates the full extent per-pixel, forest extent per hectare
+        ### and forest extent per pixel 0.00025x0.00025 deg derivative outputs
         uu.print_log("STEP 1: Creating derivative per-pixel and forest extent outputs")
         uu.print_log(f'Input pattern: {input_pattern}')
         uu.print_log(f'Output patterns: {output_patterns}')
@@ -168,7 +169,8 @@ def mp_derivative_outputs(tile_id_list_outer):
             pool.join()
 
 
-        ### STEP 2: Converts the 10x10 degree Hansen tiles that are in windows of 40000x1 pixels to windows of 160x160 pixels.
+        ### STEP 2: Converts the forest extent 10x10 degree Hansen tiles that
+        ### are in windows of 40000x1 pixels to windows of 160x160 pixels.
         ### This will allow the 0.00025x0.00025 deg pixels in each window to be summed into the aggregated pixels
         ### in the next step.
         uu.print_log("STEP 2: Rewindow tiles")

--- a/analyses/mp_derivative_outputs.py
+++ b/analyses/mp_derivative_outputs.py
@@ -16,7 +16,7 @@ Forest extent is defined in the methods section of Harris et al. 2021 Nature Cli
 within the model extent, pixels that have TCD>30 OR Hansen gain OR mangrove biomass.
 More formally, forest extent is:
 ((TCD2000>30 AND WHRC AGB2000>0) OR Hansen gain=1 OR mangrove AGB2000>0) NOT IN pre-2000 plantations.
-The WHRC AGB2000 and pre-2000 plantations conditions were set in mp_model_extent.py, so they don't show up here.
+The WHRC AGB2000 condition was set in mp_model_extent.py, so it doesn't show up here.
 
 python -m analyses.mp_derivative_outputs -t std -l 00N_000E -nu
 python -m analyses.mp_derivative_outputs -t std -l all
@@ -104,6 +104,7 @@ def mp_derivative_outputs(tile_id_list_outer):
     uu.s3_flexible_download(cn.tcd_dir, cn.pattern_tcd, cn.docker_tile_dir, cn.SENSIT_TYPE, tile_id_list_outer)
     uu.s3_flexible_download(cn.gain_dir, cn.pattern_gain_data_lake, cn.docker_tile_dir, cn.SENSIT_TYPE, tile_id_list_outer)
     uu.s3_flexible_download(cn.mangrove_biomass_2000_dir, cn.pattern_mangrove_biomass_2000, cn.docker_tile_dir, cn.SENSIT_TYPE, tile_id_list_outer)
+    uu.s3_flexible_download(cn.plant_pre_2000_processed_dir, cn.pattern_plant_pre_2000, cn.docker_tile_dir, cn.SENSIT_TYPE, tile_id_list_outer)
 
     # Iterates through the types of tiles to be processed
     for input_dir, download_pattern_name in download_dict.items():

--- a/carbon_pools/create_carbon_pools.py
+++ b/carbon_pools/create_carbon_pools.py
@@ -83,7 +83,7 @@ def create_AGC(tile_id, carbon_pool_extent):
     # Names of the input tiles. Creates the names even if the files don't exist.
     removal_forest_type = uu.sensit_tile_rename(cn.SENSIT_TYPE, tile_id, cn.pattern_removal_forest_type)
     mangrove_biomass_2000 = uu.sensit_tile_rename(cn.SENSIT_TYPE, tile_id, cn.pattern_mangrove_biomass_2000)
-    gain = uu.sensit_tile_rename(cn.SENSIT_TYPE, cn.pattern_gain_ec2, tile_id)
+    gain = f'{tile_id}_{cn.pattern_gain_ec2}.tif'
     annual_gain_AGC = uu.sensit_tile_rename(cn.SENSIT_TYPE, tile_id, cn.pattern_annual_gain_AGC_all_types)
     cumul_gain_AGCO2 = uu.sensit_tile_rename(cn.SENSIT_TYPE, tile_id, cn.pattern_cumul_gain_AGCO2_all_types)
     natrl_forest_biomass_2000 = uu.sensit_tile_rename_biomass(cn.SENSIT_TYPE, tile_id)

--- a/data_prep/mp_model_extent.py
+++ b/data_prep/mp_model_extent.py
@@ -1,6 +1,6 @@
 """
 This script creates a binary raster of the model extent at the pixel level.
-The model extent is ((TCD2000>0 AND WHRC AGB2000>0) OR Hansen gain=1 OR mangrove AGB2000>0) NOT IN pre-2000 plantations
+The model extent is ((TCD2000>0 AND WHRC AGB2000>0) OR Hansen gain=1 OR mangrove AGB2000>0).
 The rest of the model uses this to mask its extent.
 For biomass_swap sensitivity analysis, NASA JPL AGB 2000 replaces WHRC 2000.
 For legal_Amazon_loss sensitivity analysis, PRODES 2000 forest extent replaces Hansen tree cover 2000 and Hansen gain
@@ -49,8 +49,7 @@ def mp_model_extent(tile_id_list):
     # Files to download for this script.
     download_dict = {
                     cn.mangrove_biomass_2000_dir: [cn.pattern_mangrove_biomass_2000],
-                    cn.gain_dir: [cn.pattern_gain_data_lake],
-                    cn.plant_pre_2000_processed_dir: [cn.pattern_plant_pre_2000]
+                    cn.gain_dir: [cn.pattern_gain_data_lake]
     }
 
     if cn.SENSIT_TYPE == 'legal_Amazon_loss':

--- a/readme.md
+++ b/readme.md
@@ -55,12 +55,15 @@ and mapping on the Global Forest Watch web platform or at small scales (where 30
 Individual emissions can be assigned years based on Hansen loss during further analyses 
 but removals and net flux are cumulative over the entire model run and cannot be assigned specific years. 
 This 30-m output is in megagrams (Mg) CO2e/ha 2001-2021 (i.e. densities) and includes all tree cover densities ("full extent"):
-`(((TCD2000>0 AND WHRC AGB2000>0) OR Hansen gain=1 OR mangrove AGB2000>0) NOT IN pre-2000 plantations)`.
+`((TCD2000>0 AND WHRC AGB2000>0) OR Hansen gain=1 OR mangrove AGB2000>0)`.
 However, the model is designed to be used specifically for forests, so the model creates three derivative 30-m
-outputs for each key output (gross emissions, gross removals, net flux) as well (only for the standard model, not for sensitivity analyses):
+outputs for each key output (gross emissions, gross removals, net flux) as well (only for the standard model, not for sensitivity analyses).
+To that end, the "forest extent" rasters also have pre-2000 oil palm plantations in Indonesia and Malaysia removed
+from them because carbon emissions and removals in those pixels would represent agricultural/tree crop emissions,
+not forest/forest loss. 
 
 1) Mg CO2e per pixel values for the full model extent (all tree cover densities): 
-   `(((TCD2000>0 AND WHRC AGB2000>0) OR Hansen gain=1 OR mangrove AGB2000>0) NOT IN pre-2000 plantations)`
+   `((TCD2000>0 AND WHRC AGB2000>0) OR Hansen gain=1 OR mangrove AGB2000>0)`
 2) Mg CO2e per hectare values for forest pixels only (colloquially, TCD>30 or Hansen gain pixels): 
    `(((TCD2000>30 AND WHRC AGB2000>0) OR Hansen gain=1 OR mangrove AGB2000>0) NOT IN pre-2000 plantations)`
 3) Mg CO2e per pixel values for forest pixels only (colloquially, TCD>30 or Hansen gain pixels):  

--- a/removals/forest_age_category_IPCC.py
+++ b/removals/forest_age_category_IPCC.py
@@ -157,7 +157,6 @@ def forest_age_category(tile_id, gain_table_dict, pattern):
             # Logic tree for assigning age categories begins here
             # Code 1 = young (<20 years) secondary forest, code 2 = old (>20 year) secondary forest, code 3 = primary forest
             # model_extent_window ensures that there is both biomass and tree cover in 2000 OR mangroves OR tree cover gain
-            # WITHOUT pre-2000 plantations
 
             # For every model version except legal_Amazon_loss sensitivity analysis, which has its own rules about age assignment
 
@@ -181,12 +180,10 @@ def forest_age_category(tile_id, gain_table_dict, pattern):
 
                 # Gain-only pixels
                 # If there is gain, the pixel doesn't need biomass or canopy cover.
-                # The role of model_extent_window here is to exclude the pre-2000 plantations.
                 dst_data[np.where((model_extent_window > 0) & (gain_window == 1) & (loss_window == 0))] = 1
 
                 # Pixels with loss and gain
                 # If there is gain with loss, the pixel doesn't need biomass or canopy cover.
-                # The role of model_extent_window here is to exclude the pre-2000 plantations.
                 dst_data[np.where((model_extent_window > 0) & (gain_window == 1) & (loss_window > 0))] = 1
 
             # For legal_Amazon_loss sensitivity analysis


### PR DESCRIPTION
…ded it to forest extent part of derivative output stage. Tested both stages and updated documentation. Changed documentation throughout repo (including readme).

Also, fixed mistake in carbon pool creation step that wasn't registering the gain tile.

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Make sure you are requesting to pull a topic/feature/bugfix branch (right side). Don't request your master!
- [x] Make sure you are making a pull request against the develop branch (left side). Also you should start your branch off our develop.
- [x] Check the commit's or even all commits' message styles matches our requested structure.
- [x] Check your code additions will fail neither code linting checks nor unit test.



## Pull request type

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
1. Model extent stage cuts out pre-2000 oil palm plantations in Indonesia and Malaysia. They are excluded from the entire model because land use change has already occurred in them, so tree cover loss since 2001 isn't real forest loss but instead is harvesting of existing oil palm trees. Thus, the full extent and forest extent outputs of the model didn't have any results for pre-2000 plantation areas. 


## What is the new behavior?
1. Pre-2000 oil palm areas are kept in for the entire model and only removed during mp_create_derivative_outputs when the forest extent outputs are created. Thus, emissions, removals, and net flux are calculated in pre-2000 plantation areas for full extent results but not for forest extent; fluxes are not shown in pre-2000 plantation areas for the forest extent per hectare and per pixel outputs (and are not used in the aggregated maps). 

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Forest extent outputs should continue to be used for all cases except where fluxes for all tree cover densities are absolutely necessary. 