### PR TITLE
Use Intelligent Tiering for S3 tile uploads.

### DIFF
--- a/universal_util.py
+++ b/universal_util.py
@@ -918,7 +918,7 @@ def upload_final_set(upload_dir, pattern):
     print_log(f'Uploading tiles with pattern {pattern} to {upload_dir}')
 
     cmd = ['aws', 's3', 'cp', cn.docker_tile_dir, upload_dir, '--exclude', '*', '--include', '*{}*tif'.format(pattern),
-           '--recursive', '--no-progress']
+           '--recursive', '--no-progress', '--storage-class', 'INTELLIGENT_TIERING']
     try:
         log_subprocess_output_full(cmd)
         print_log(f'  Upload of tiles with {pattern} pattern complete!')
@@ -935,8 +935,8 @@ def upload_final(upload_dir, tile_id, pattern):
     file = '{}_{}.tif'.format(tile_id, pattern)
 
     print_log("Uploading {}".format(file))
-    # cmd = ['aws', 's3', 'cp', file, upload_dir, '--no-sign-request', '--no-progress']
-    cmd = ['aws', 's3', 'cp', file, upload_dir, '--no-progress']
+    # cmd = ['aws', 's3', 'cp', file, upload_dir, '--no-sign-request', '--no-progress', '--storage-class', 'INTELLIGENT_TIERING']
+    cmd = ['aws', 's3', 'cp', file, upload_dir, '--no-progress', '--storage-class', 'INTELLIGENT_TIERING']
 
     try:
         log_subprocess_output_full(cmd)


### PR DESCRIPTION
The bucket that is being used has a lifecycle policy to transition new files into "Intelligent Tiering" [0].
(https://aws.amazon.com/s3/storage-classes/intelligent-tiering/).

By default the `aws s3 cp <src> <dst>` uploads into Standard storage tier unless a different tier is specified [1]. This causes an unneccessary transition action to be performed (from Standard -> I.T.) whereas if the uplaods occurred directly to the Intelligent Tiering class there would not be a "transition". The cost of the transitions is pretty small - one cent per one-thousand objects [2]. But at a scale of one-million files that's an unwelcome ten dollars.

This change is untested at this moment, but I have confidence there will be no noticeable difference in performance or function.

This is not intended to be applied to the log file uploads which tend to be small and not worth putting into Intelligent Tiering.

[0] https://aws.amazon.com/s3/storage-classes/intelligent-tiering/
[1] https://docs.aws.amazon.com/cli/latest/reference/s3/cp.html
[2] https://aws.amazon.com/s3/pricing/
